### PR TITLE
Update LORA pin definitions in variant.h

### DIFF
--- a/variants/nrf52840/diy/elecrow_lr1262/variant.h
+++ b/variants/nrf52840/diy/elecrow_lr1262/variant.h
@@ -86,13 +86,13 @@ extern "C" {
 #define PIN_SPI_SCK (32 + 13)  // P1.13 45
 #define PIN_SPI_NSS (32 + 12)  // P1.12 44
 
-#define LORA_RESET (32 + 10) // P1.10 42 // RST
-#define LORA_DIO1 (32 + 6)   // IRQ
-#define LORA_DIO2 (32 + 11)  // P1.11 43 // BUSY
-#define LORA_SCK PIN_SPI_SCK
-#define LORA_MISO PIN_SPI_MISO
-#define LORA_MOSI PIN_SPI_MOSI
-#define LORA_CS PIN_SPI_NSS
+#define LORA_DIO1   38   // P1.06
+#define LORA_CS     44   // P1.12
+#define LORA_SCK    45   // P1.13
+#define LORA_MOSI   46   // P1.14
+#define LORA_MISO   47   // P1.15
+#define LORA_DIO2   43   // P1.11 (BUSY)
+#define LORA_RESET  42   // P1.10
 
 // LORA MODULES
 #define USE_SX1262


### PR DESCRIPTION
### Summary
This PR updates the board-specific pin definitions to match the intended hardware
layout of my nRF52840 + SX1262 based board.

The changes are limited to the board variant files and are intended to prepare
the board for initial bring-up and testing.

### What was changed
- Updated LoRa (SX1262) pin mapping in the board variant
- Explicitly mapped pins to the actual P1.x connections used on the board

### Testing
- Not yet tested on hardware
- This PR is intended to enable initial testing and validation of the board