### PR TITLE
Use the authoritative key on the PKI decrypt path

### DIFF
--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -624,13 +624,13 @@ DecodeState perhapsDecode(meshtastic_MeshPacket *p)
     meshtastic_NodeInfoLite *ourNode = nullptr;
     if (p->channel == 0 && isToUs(p) && p->to > 0 && !isBroadcast(p->to) && rawSize > MESHTASTIC_PKC_OVERHEAD &&
         (ourNode = nodeDB->getMeshNode(p->to)) != nullptr && ourNode->public_key.size > 0) {
-        // Resolve the sender's public key only for actual PKI-decrypt candidates: prefer NodeDB
-        // (hot store or warm tier), else a not-yet-committed key held during an in-progress
-        // key-verification handshake. On a full NodeDB miss, copyPublicKey() falls through to a
-        // linear scan of TrafficManagement's large NodeInfo cache, so it must not run for every
-        // encrypted channel packet from an unknown sender - only for packets we might decrypt.
+        // Resolve the sender's public key only for actual PKI-decrypt candidates. Use
+        // copyPublicKeyAuthoritative (hot store or warm tier only), not the opportunistic
+        // copyPublicKey: authenticated DM attribution (pki_encrypted, p->from) must rest on
+        // authoritative keys, never on the ephemeral TOFU TrafficManagement NodeInfo cache. A
+        // not-yet-committed key from an in-progress key-verification handshake is tried below.
         meshtastic_NodeInfoLite_public_key_t remotePublic = {0, {0}};
-        bool haveRemoteKey = nodeDB->copyPublicKey(p->from, remotePublic);
+        bool haveRemoteKey = nodeDB->copyPublicKeyAuthoritative(p->from, remotePublic);
         // A pending key is an unverified identity claim supplied by whoever opened the handshake, so it is
         // accepted only for the exchange itself (checked after decode). perhapsEncode applies the same rule.
         bool havePendingKey = false;


### PR DESCRIPTION
Targets this PR's branch (#11050). The tier-3 change makes NodeDB::copyPublicKey fall through to the ephemeral TMM NodeInfo cache, and Router::perhapsDecode uses it to resolve the sender key on the inbound PKI-decrypt path. A DM decrypted with a cache-resolved TOFU key is then stamped pki_encrypted and attributed to p->from, so authenticated DM attribution rests partly on the opportunistic cache. This switches that one call to copyPublicKeyAuthoritative (hot/warm only); the outbound encrypt-to pool keeps the opportunistic lookup.