### PR TITLE
Harden admin transaction restart suppression

### DIFF
--- a/.github/actions/setup-native/action.yml
+++ b/.github/actions/setup-native/action.yml
@@ -11,4 +11,4 @@ runs:
     - name: Install libs needed for native build
       shell: bash
       run: |
-        sudo apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev libjsoncpp-dev openssl libssl-dev libulfius-dev liborcania-dev libusb-1.0-0-dev libi2c-dev libuv1-dev
+        sudo apt-get install -y libbluetooth-dev libgpiod-dev libyaml-cpp-dev libjsoncpp-dev openssl libssl-dev libulfius-dev liborcania-dev libusb-1.0-0-dev libi2c-dev libuv1-dev libcurl4-gnutls-dev

--- a/.github/workflows/build_windows_bin.yml
+++ b/.github/workflows/build_windows_bin.yml
@@ -47,6 +47,7 @@ jobs:
             mingw-w64-ucrt-x86_64-libuv
             mingw-w64-ucrt-x86_64-jsoncpp
             mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-curl
             mingw-w64-ucrt-x86_64-libusb
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-ninja

--- a/.github/workflows/main_matrix.yml
+++ b/.github/workflows/main_matrix.yml
@@ -140,7 +140,7 @@ jobs:
     secrets: inherit
 
   MacOS:
-    if: ${{ github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
+    if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +155,7 @@ jobs:
     # secrets: inherit
 
   Windows:
-    if: ${{ github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
+    if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -182,7 +182,7 @@ jobs:
     uses: ./.github/workflows/test_native.yml
 
   build-wasm:
-    if: ${{ github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
+    if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
     # Build the WebAssembly portduino node ([env:native-wasm]) as part of normal CI,
     # like the other platforms. It's a dedicated job (not a row in the `build`
     # matrix) because its artifact is meshnode.{mjs,wasm} - not a flashable
@@ -191,7 +191,7 @@ jobs:
     uses: ./.github/workflows/build_portduino_wasm.yml
 
   docker:
-    if: ${{ github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
+    if: ${{ !contains(github.ref_name, 'event/') && github.event_name != 'schedule' && github.event.inputs.nightly != 'true' }}
     permissions: # Needed for pushing to GHCR.
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         curl wget g++ zip git ca-certificates pkg-config \
         python3-pip python3-grpc-tools \
         libgpiod-dev libyaml-cpp-dev libjsoncpp-dev libbluetooth-dev libi2c-dev libuv1-dev \
-        libusb-1.0-0-dev libulfius-dev liborcania-dev libssl-dev \
+        libcurl4-gnutls-dev libusb-1.0-0-dev libulfius-dev liborcania-dev libssl-dev \
         libx11-dev libinput-dev libxkbcommon-x11-dev libsqlite3-dev libsdl2-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -U platformio \
@@ -55,7 +55,7 @@ USER root
 
 RUN apt-get update && apt-get --no-install-recommends -y install \
         libc-bin libc6 libgpiod3 libyaml-cpp0.8 libjsoncpp26 libi2c0 libuv1t64 libusb-1.0-0-dev \
-        liborcania2.3 libulfius2.7t64 libssl3t64 \
+        libcurl4t64 liborcania2.3 libulfius2.7t64 libssl3t64 \
         libx11-6 libinput10 libxkbcommon-x11-0 libsdl2-2.0-0 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /var/lib/meshtasticd \

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -17,7 +17,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apk --no-cache add \
         bash g++ libstdc++-dev linux-headers zip git ca-certificates libbsd-dev \
         py3-pip py3-grpcio-tools \
-        libgpiod-dev yaml-cpp-dev jsoncpp-dev bluez-dev \
+        libgpiod-dev yaml-cpp-dev jsoncpp-dev bluez-dev curl-dev \
         libusb-dev i2c-tools-dev libuv-dev openssl-dev pkgconf argp-standalone \
         libx11-dev libinput-dev libxkbcommon-dev sqlite-dev sdl2-dev \
     && rm -rf /var/cache/apk/* \
@@ -50,7 +50,7 @@ USER root
 
 RUN apk --no-cache add \
         shadow libstdc++ libbsd libgpiod yaml-cpp jsoncpp libusb \
-        i2c-tools libuv libx11 libinput libxkbcommon sdl2 \
+        libcurl i2c-tools libuv libx11 libinput libxkbcommon sdl2 \
     && rm -rf /var/cache/apk/* \
     && mkdir -p /var/lib/meshtasticd \
     && mkdir -p /etc/meshtasticd/config.d \

--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ lib_deps =
 [device-ui_base]
 lib_deps =
 	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
-	https://github.com/meshtastic/device-ui/archive/ef573c368767625ffbe8c32cf921ea7366f2dd53.zip
+	https://github.com/meshtastic/device-ui/archive/2f5a7dd9c9af19b6f3a2ddab1477f75aceae281b.zip
 
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]

--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ lib_deps =
 [device-ui_base]
 lib_deps =
 	# renovate: datasource=git-refs depName=meshtastic/device-ui packageName=https://github.com/meshtastic/device-ui gitBranch=master
-	https://github.com/meshtastic/device-ui/archive/2f5a7dd9c9af19b6f3a2ddab1477f75aceae281b.zip
+	https://github.com/meshtastic/device-ui/archive/bcb327f058469282408eed93e27249d6447de9c0.zip
 
 ; Common libs for environmental measurements in telemetry module
 [environmental_base]

--- a/src/MessageStore.cpp
+++ b/src/MessageStore.cpp
@@ -215,7 +215,12 @@ const StoredMessage *MessageStore::tryAddFromPacket(const meshtastic_MeshPacket 
     sm.channelIndex = packet.channel;
 
     const char *payload = reinterpret_cast<const char *>(packet.decoded.payload.bytes);
-    size_t len = strnlen(payload, MAX_MESSAGE_SIZE - 1);
+    // payload.bytes is not NUL-terminated, so bound by the received size too: a shorter message
+    // stored after a longer one would otherwise pick up the previous occupant's trailing bytes.
+    size_t avail = packet.decoded.payload.size;
+    if (avail > MAX_MESSAGE_SIZE - 1)
+        avail = MAX_MESSAGE_SIZE - 1;
+    size_t len = strnlen(payload, avail);
     sm.textOffset = storeTextInPool(payload, len);
     sm.textLength = len;
 

--- a/src/UptimeClock.cpp
+++ b/src/UptimeClock.cpp
@@ -1,0 +1,33 @@
+// See UptimeClock.h for the full contract.
+#include "UptimeClock.h"
+#include <Arduino.h>
+
+uint32_t Time::getMillis()
+{
+#ifdef PIO_UNIT_TESTING
+    if (Time::useTestClock)
+        return Time::testNowMs;
+#endif
+    return millis();
+}
+
+uint64_t Time::getMillis64()
+{
+    static uint32_t lastLow = 0;  // last 32-bit sample
+    static uint32_t highWord = 0; // number of observed wraps
+
+    uint32_t now = Time::getMillis();
+#ifdef PIO_UNIT_TESTING
+    // A test swapping clock sources (real <-> injected) can make `now` jump backward for
+    // reasons other than a genuine wrap - rebase rather than miscount it as one.
+    if (Time::clockSourceChanged) {
+        lastLow = now;
+        highWord = 0;
+        Time::clockSourceChanged = false;
+    }
+#endif
+    if (now < lastLow)
+        highWord++; // low word wrapped since last call
+    lastLow = now;
+    return (static_cast<uint64_t>(highWord) << 32) | now;
+}

--- a/src/UptimeClock.h
+++ b/src/UptimeClock.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+
+// Monotonic uptime clock, injectable so tests can drive a virtual timebase instead of sleeping.
+// Uptime only; see gps/RTC.h for wall-clock. Not named Time.h: -Isrc would shadow C's <time.h>.
+namespace Time
+{
+#ifdef PIO_UNIT_TESTING
+// Test-only virtual clock; OFF by default so suites relying on real time are unaffected.
+inline uint32_t testNowMs = 0;
+inline bool useTestClock = false;
+inline bool clockSourceChanged = true; // forces getMillis64() to rebase its wrap accumulator
+
+inline void setTestMillis(uint32_t ms)
+{
+    testNowMs = ms;
+    useTestClock = true;
+    clockSourceChanged = true;
+}
+inline void advanceTestMillis(uint32_t deltaMs)
+{
+    // Advancing from 0 after getMillis64() sampled the real clock steps backward, which would
+    // otherwise be miscounted as a wrap.
+    if (!useTestClock)
+        clockSourceChanged = true;
+    testNowMs += deltaMs;
+    useTestClock = true;
+}
+// Restore real-clock behaviour (call in test tearDown if a suite mixes real and fake time).
+inline void useRealClock()
+{
+    useTestClock = false;
+    testNowMs = 0;
+    clockSourceChanged = true;
+}
+#endif
+
+/// Milliseconds since boot, 32-bit (wraps ~49.7 days). Drop-in for millis().
+uint32_t getMillis();
+
+/// Milliseconds since boot, 64-bit, rollover-immune. Must be polled at least once per ~49.7-day
+/// wrap window to catch every wrap, and keeps mutable static carry state, so it is NOT ISR-safe.
+uint64_t getMillis64();
+
+} // namespace Time

--- a/src/gps/RTC.cpp
+++ b/src/gps/RTC.cpp
@@ -2,6 +2,7 @@
 #include "configuration.h"
 #include "detect/ScanI2C.h"
 #include "main.h"
+#include "mesh/MeshService.h"
 #include "modules/NodeInfoModule.h"
 #include <Throttle.h>
 #include <sys/time.h>
@@ -17,11 +18,15 @@ uint32_t lastSetFromPhoneNtpOrGps = 0;
 static uint32_t lastTimeValidationWarning = 0;
 static const uint32_t TIME_VALIDATION_WARNING_INTERVAL_MS = 15000; // 15 seconds
 
-static void triggerNodeInfoCheckOnTimeSource(RTCQuality oldQuality, RTCQuality newQuality)
+static void onTimeSourceQualityChanged(RTCQuality oldQuality, RTCQuality newQuality)
 {
     if (oldQuality == RTCQualityNone && newQuality > RTCQualityNone && nodeInfoModule) {
         LOG_DEBUG("Time source acquired (%s -> %s), triggering NodeInfo recheck", RtcName(oldQuality), RtcName(newQuality));
         nodeInfoModule->triggerImmediateNodeInfoCheck();
+    }
+    if (oldQuality < RTCQualityFromNet && newQuality >= RTCQualityFromNet && service) {
+        LOG_DEBUG("RTC net quality reached (%s -> %s), reconciling rx_time", RtcName(oldQuality), RtcName(newQuality));
+        service->reconcilePendingRxTimes();
     }
 }
 
@@ -128,7 +133,7 @@ RTCSetResult readFromRTC()
             timeStartMsec = now;
             zeroOffsetSecs = tv.tv_sec;
             currentQuality = RTCQualityDevice;
-            triggerNodeInfoCheckOnTimeSource(oldQuality, currentQuality);
+            onTimeSourceQualityChanged(oldQuality, currentQuality);
         }
         return RTCSetResultSuccess;
     } else {
@@ -174,7 +179,7 @@ RTCSetResult readFromRTC()
             timeStartMsec = now;
             zeroOffsetSecs = tv.tv_sec;
             currentQuality = RTCQualityDevice;
-            triggerNodeInfoCheckOnTimeSource(oldQuality, currentQuality);
+            onTimeSourceQualityChanged(oldQuality, currentQuality);
         }
         return RTCSetResultSuccess;
     } else {
@@ -210,7 +215,7 @@ RTCSetResult readFromRTC()
                 timeStartMsec = now;
                 zeroOffsetSecs = tv.tv_sec;
                 currentQuality = RTCQualityDevice;
-                triggerNodeInfoCheckOnTimeSource(oldQuality, currentQuality);
+                onTimeSourceQualityChanged(oldQuality, currentQuality);
             }
             return RTCSetResultSuccess;
         }
@@ -235,7 +240,7 @@ RTCSetResult readFromRTC()
             timeStartMsec = now;
             zeroOffsetSecs = tv.tv_sec;
             currentQuality = RTCQualityDevice;
-            triggerNodeInfoCheckOnTimeSource(oldQuality, currentQuality);
+            onTimeSourceQualityChanged(oldQuality, currentQuality);
         }
         return RTCSetResultSuccess;
     }
@@ -381,7 +386,7 @@ RTCSetResult perhapsSetRTC(RTCQuality q, const struct timeval *tv, bool forceUpd
 #endif
 
         readFromRTC();
-        triggerNodeInfoCheckOnTimeSource(oldQuality, currentQuality);
+        onTimeSourceQualityChanged(oldQuality, currentQuality);
         return RTCSetResultSuccess;
     } else {
         return RTCSetResultNotSet; // RTC was already set with a higher quality time

--- a/src/mesh/Default.cpp
+++ b/src/mesh/Default.cpp
@@ -92,7 +92,7 @@ uint32_t Default::getConfiguredOrMinimumValue(uint32_t configured, uint32_t minV
 uint8_t Default::getConfiguredOrDefaultHopLimit(uint8_t configured)
 {
 #if USERPREFS_EVENT_MODE
-    return (configured > HOP_RELIABLE) ? HOP_RELIABLE : config.lora.hop_limit;
+    return (configured >= eventModeHopLimit) ? eventModeHopLimit : config.lora.hop_limit;
 #else
     return (configured >= HOP_MAX) ? HOP_MAX : config.lora.hop_limit;
 #endif

--- a/src/mesh/Default.h
+++ b/src/mesh/Default.h
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <meshUtils.h>
+#include <type_traits>
 #define ONE_DAY 24 * 60 * 60
 #define ONE_MINUTE_MS 60 * 1000
 #define THIRTY_SECONDS_MS 30 * 1000
@@ -75,7 +76,20 @@ enum class TrafficType { POSITION, TELEMETRY };
 
 class Default
 {
+#if USERPREFS_EVENT_MODE && defined(USERPREFS_EVENT_MODE_HOP_LIMIT)
+    static constexpr auto eventModeHopLimitSetting = USERPREFS_EVENT_MODE_HOP_LIMIT;
+#else
+    static constexpr auto eventModeHopLimitSetting = HOP_RELIABLE;
+#endif
+    using EventModeHopLimitType = typename std::remove_cv<decltype(eventModeHopLimitSetting)>::type;
+    static_assert(std::is_integral<EventModeHopLimitType>::value && !std::is_same<EventModeHopLimitType, bool>::value &&
+                      eventModeHopLimitSetting >= 0 && eventModeHopLimitSetting <= HOP_MAX,
+                  "USERPREFS_EVENT_MODE_HOP_LIMIT must be an integer between 0 and 7");
+
   public:
+    static constexpr uint8_t eventModeHopLimit = static_cast<uint8_t>(eventModeHopLimitSetting);
+    static constexpr uint8_t eventModeRelayHopLimit = eventModeHopLimit > 0 ? eventModeHopLimit - 1 : 0;
+
     static uint32_t getConfiguredOrDefaultMs(uint32_t configuredInterval);
     static uint32_t getConfiguredOrDefaultMs(uint32_t configuredInterval, uint32_t defaultInterval);
     static uint32_t getConfiguredOrDefault(uint32_t configured, uint32_t defaultValue);

--- a/src/mesh/LR11x0Interface.cpp
+++ b/src/mesh/LR11x0Interface.cpp
@@ -247,6 +247,7 @@ template <typename T> void LR11x0Interface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError());
 }
 

--- a/src/mesh/LR20x0Interface.cpp
+++ b/src/mesh/LR20x0Interface.cpp
@@ -253,6 +253,7 @@ template <typename T> void LR20x0Interface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     // LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError()); // not implemented for LR20x0, but noop for LR11x0
     // too(!)
 }

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -12,6 +12,7 @@
 #include "Power.h"
 #include "PowerFSM.h"
 #include "TypeConversions.h"
+#include "UptimeClock.h"
 #include "gps/RTC.h"
 #include "graphics/draw/MessageRenderer.h"
 #include "main.h"
@@ -180,6 +181,36 @@ NodeNum MeshService::getNodenumFromRequestId(uint32_t request_id)
     return nodenum;
 }
 
+// Back-calculate the real epoch for any queued packet still carrying a millis() rx_time
+// placeholder, now that the clock is trustworthy.
+void MeshService::reconcilePendingRxTimes()
+{
+    const uint32_t nowEpoch = getValidTime(RTCQualityFromNet);
+    if (nowEpoch == 0) // called before the clock was actually valid - nothing to reconcile against
+        return;
+    const uint32_t nowMillis = Time::getMillis();
+
+    // Rotate the queue once. TypedQueue is strictly FIFO on both backends, so dequeueing and
+    // re-enqueueing every element in turn leaves the delivery order unchanged.
+    for (int remaining = toPhoneQueue.numUsed(); remaining > 0; remaining--) {
+        meshtastic_MeshPacket *p = toPhoneQueue.dequeuePtr(0);
+        if (!p) // drained from under us - nothing left to rotate
+            break;
+        if (!p->has_rx_time) {
+            // Unsigned subtraction is wraparound-safe; rx_time is a 32-bit wire field, so the
+            // placeholder was never wider than 32 bits to begin with.
+            const uint32_t elapsedMs = nowMillis - p->rx_time;
+            p->rx_time = nowEpoch - (elapsedMs / 1000);
+            p->has_rx_time = true;
+        }
+        if (!toPhoneQueue.enqueue(p, 0)) { // mirrors sendToPhone()'s degrade-on-failure path
+            LOG_CRIT("Failed to requeue a packet into toPhoneQueue!");
+            releaseToPool(p);
+            fromNum++; // notify observers so the phone can resync
+        }
+    }
+}
+
 #if MESHTASTIC_ENABLE_FRAME_INJECTION
 // Deliver a client-supplied frame into the receive pipeline as if it arrived off the LoRa chip. Mirrors
 // the portduino SimRadio SIMULATOR_APP unwrap so the same host wire format works on real hardware: the
@@ -220,7 +251,9 @@ void MeshService::injectAsReceived(meshtastic_MeshPacket &p)
         mp->rx_rssi = -40;
         mp->has_rx_rssi = true;
     }
-    mp->rx_time = getValidTime(RTCQualityFromNet);
+    // dispatchReceived() restamps this when the packet re-enters the pipeline below; stamp it
+    // here anyway so the packet is never observable with an unset arrival time.
+    stampRxTime(mp);
     LOG_INFO("inject: RX from=0x%08x to=0x%08x id=0x%08x ch=%d %s", mp->from, mp->to, mp->id, mp->channel,
              mp->which_payload_variant == meshtastic_MeshPacket_encrypted_tag ? "encrypted" : "decoded");
     router->enqueueReceivedMessage(mp);
@@ -258,7 +291,8 @@ void MeshService::handleToRadio(meshtastic_MeshPacket &p)
     if (p.id == 0)
         p.id = generatePacketId(); // If the phone didn't supply one, then pick one
 
-    p.rx_time = getValidTime(RTCQualityFromNet); // Record the time the packet arrived from the phone
+    // Record the time the packet arrived from the phone.
+    stampRxTime(&p);
 
     IF_SCREEN(if (p.decoded.portnum == meshtastic_PortNum_TEXT_MESSAGE_APP && p.decoded.payload.size > 0 &&
                   p.to != NODENUM_BROADCAST && p.to != 0) // DM only
@@ -595,6 +629,11 @@ bool MeshService::isToPhoneQueueEmpty()
 
 uint32_t MeshService::GetTimeSinceMeshPacket(const meshtastic_MeshPacket *mp)
 {
+    // rx_time may be a millis() placeholder while has_rx_time is false - don't age it as
+    // wall-clock, and don't pass it off as "just now" either.
+    if (!mp->has_rx_time)
+        return SINCE_UNKNOWN;
+
     uint32_t now = getTime();
 
     uint32_t last_seen = mp->rx_time;

--- a/src/mesh/MeshService.cpp
+++ b/src/mesh/MeshService.cpp
@@ -216,8 +216,10 @@ void MeshService::injectAsReceived(meshtastic_MeshPacket &p)
         return;
     if (mp->rx_snr == 0) // plausible synthetic link metadata unless the caller set it
         mp->rx_snr = 8;
-    if (mp->rx_rssi == 0)
+    if (!mp->has_rx_rssi) { // rx_rssi has explicit presence; only fabricate if the caller didn't supply a real one
         mp->rx_rssi = -40;
+        mp->has_rx_rssi = true;
+    }
     mp->rx_time = getValidTime(RTCQualityFromNet);
     LOG_INFO("inject: RX from=0x%08x to=0x%08x id=0x%08x ch=%d %s", mp->from, mp->to, mp->id, mp->channel,
              mp->which_payload_variant == meshtastic_MeshPacket_encrypted_tag ? "encrypted" : "decoded");

--- a/src/mesh/MeshService.h
+++ b/src/mesh/MeshService.h
@@ -137,6 +137,10 @@ class MeshService
     // search the queue for a request id and return the matching nodenum
     NodeNum getNodenumFromRequestId(uint32_t request_id);
 
+    // Rewrite any queued-for-phone packet still carrying a millis() rx_time placeholder into a
+    // real epoch, now that the wall clock is trustworthy.
+    void reconcilePendingRxTimes();
+
     // Release QueueStatus packet to pool
     void releaseQueueStatusToPool(meshtastic_QueueStatus *p) { queueStatusPool.release(p); }
 
@@ -205,6 +209,7 @@ class MeshService
 
     ErrorCode sendQueueStatusToPhone(const meshtastic_QueueStatus &qs, ErrorCode res, uint32_t mesh_packet_id);
 
+    /// Seconds since the packet arrived, or SINCE_UNKNOWN if it carries no trustworthy rx_time.
     uint32_t GetTimeSinceMeshPacket(const meshtastic_MeshPacket *mp);
 
   private:

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -1,4 +1,5 @@
 #include "NextHopRouter.h"
+#include "Default.h"
 #include "MeshTypes.h"
 #include "meshUtils.h"
 #if !MESHTASTIC_EXCLUDE_TRACEROUTE
@@ -8,6 +9,18 @@
 #include "modules/TrafficManagementModule.h"
 #endif
 #include "NodeDB.h"
+
+#if USERPREFS_EVENT_MODE
+static void capEventRelayHops(meshtastic_MeshPacket *packet)
+{
+    if (packet->hop_limit <= Default::eventModeRelayHopLimit)
+        return;
+
+    const uint8_t reduction = packet->hop_limit - Default::eventModeRelayHopLimit;
+    packet->hop_start = reduction <= packet->hop_start ? packet->hop_start - reduction : 0;
+    packet->hop_limit = Default::eventModeRelayHopLimit;
+}
+#endif
 
 NextHopRouter::NextHopRouter() {}
 
@@ -26,6 +39,9 @@ bool NextHopRouter::relayOpaquePacket(const meshtastic_MeshPacket *p)
     if (!relay)
         return false;
     relay->hop_limit--;
+#if USERPREFS_EVENT_MODE
+    capEventRelayHops(relay);
+#endif
     relay->relay_node = nodeDB->getLastByteOfNodeNum(getNodeNum());
     // The interface declines some packets (NODENUM_BROADCAST_NO_LORA) with ERRNO_SHOULD_RELEASE,
     // which leaves the copy ours to free. Dropping it here would leak a pool slot per opaque frame.
@@ -211,11 +227,7 @@ bool NextHopRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                         LOG_INFO("favorite-ROUTER/CLIENT_BASE-to-ROUTER/CLIENT_BASE rebroadcast: preserving hop_limit");
                     }
 #if USERPREFS_EVENT_MODE
-                    if (tosend->hop_limit > 2) {
-                        // if we are "correcting" the hop_limit, "correct" the hop_start by the same amount to preserve hops away.
-                        tosend->hop_start -= (tosend->hop_limit - 2);
-                        tosend->hop_limit = 2;
-                    }
+                    capEventRelayHops(tosend);
 #endif
 
                     ErrorCode res =

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3504,10 +3504,9 @@ void NodeDB::addFromContact(meshtastic_SharedContact contact)
  */
 bool NodeDB::updateUser(uint32_t nodeId, meshtastic_User &p, uint8_t channelIndex, bool xeddsaSigned)
 {
-    // Only a signed update may change the identity of a node that has proven it signs; our own record is
-    // exempt. Checked before getOrCreateMeshNode so a refused update cannot evict or write the warm tier.
-    const meshtastic_NodeInfoLite *existing = getMeshNode(nodeId);
-    if (nodeId != getNodeNum() && existing && nodeInfoLiteHasXeddsaSigned(existing) && !xeddsaSigned) {
+    // Only a signed update may change the identity of a proven signer; our own record is exempt.
+    // Checked before getOrCreateMeshNode so a refusal cannot evict; isKnownXeddsaSigner covers the warm tier.
+    if (nodeId != getNodeNum() && isKnownXeddsaSigner(nodeId) && !xeddsaSigned) {
         LOG_WARN("Refusing unsigned identity update for node 0x%08x that previously signed", nodeId);
         return false;
     }

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -202,7 +202,9 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
         if (ostream) {
             const auto *vec = static_cast<const std::vector<meshtastic_NodeInfoLite> *>(iter->pData);
             for (auto item : *vec) {
-                item.snr_q4 = (int32_t)(item.snr * 4.0f);
+                // Round rather than truncate: truncation wiped any |SNR| < 0.25 dB to exactly
+                // 0, which collided with the "never stored" sentinel below.
+                item.snr_q4 = (int32_t)lroundf(item.snr * 4.0f);
                 item.snr = 0.0f;
                 if (!pb_encode_tag_for_field(ostream, iter))
                     return false;
@@ -214,8 +216,14 @@ bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostre
             meshtastic_NodeInfoLite node = meshtastic_NodeInfoLite_init_zero;
             auto *vec = static_cast<std::vector<meshtastic_NodeInfoLite> *>(iter->pData);
             if (pb_decode(istream, meshtastic_NodeInfoLite_fields, &node)) {
-                if (node.snr_q4)
+                // snr_q4 = 0 is byte-identical to "field never written" but 0 dB is valid.
+                // NODEINFO_BITFIELD_HAS_SNR_MASK disambiguates going forward; legacy
+                // records (bit clear) treat this as unknown.
+                if (nodeInfoLiteHasSnr(&node)) {
                     node.snr = node.snr_q4 / 4.0f;
+                } else if (node.snr_q4) {
+                    node.snr = node.snr_q4 / 4.0f;
+                }
                 node.snr_q4 = 0;
                 vec->push_back(node);
             }
@@ -3624,8 +3632,20 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         if (mp.rx_time) // if the packet has a valid timestamp use it to update our last_heard
             info->last_heard = mp.rx_time;
 
-        if (mp.rx_snr)
+        // Gate on the packet actually having been received over our own radio, not on rx_snr being
+        // truthy, because 0 dB is valid. TRANSPORT_LORA is set only on the real over-the-air RX path
+        // (RadioInterface.cpp); it excludes TRANSPORT_INTERNAL and TRANSPORT_MQTT, while still accepting
+        // an MQTT-origin packet that a gateway rebroadcasts onto LoRa - we genuinely measured that one
+        // ourselves. Mirrors hop histogram below.
+        // Belt-and-braces: also require has_rx_rssi, which every genuine RF-reception site sets
+        // unconditionally alongside rx_snr - unlike PhoneAPI's replay packets, which set TRANSPORT_LORA
+        // too (so the client treats restored history as if heard over the air) but never has_rx_rssi.
+        // Replay packets don't reach updateFrom() today; this check guards against a future change that
+        // routes them back through this path silently recording a replayed rx_snr as a fresh measurement.
+        if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && mp.has_rx_rssi) {
             info->snr = mp.rx_snr; // keep the most recent SNR we received for this node.
+            nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_HAS_SNR_MASK, true);
+        }
 
         nodeInfoLiteSetBit(info, NODEINFO_BITFIELD_VIA_MQTT_MASK,
                            mp.via_mqtt); // Store if we received this packet via MQTT
@@ -3637,6 +3657,11 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         // inflate the local mesh-size estimate with non-RF nodes (and they usually carry
         // hop_start==0, landing in the hop-0 bucket that pulls the recommendation lowest), so
         // exclude via_mqtt too.
+        //
+        // The std::max clamp below is deliberate, not a bug: Counting an unproven-but-real neighbor as 0 hops is the
+        // conservative direction. This intentionally does not agree with the `hopsAway >= 0`
+        // gate below, which rejects the same -1 rather than storing it as a fabricated 0 -
+        // the histogram and the stored hops_away serve different purposes.
         if (mp.transport_mechanism == meshtastic_MeshPacket_TransportMechanism_TRANSPORT_LORA && !mp.via_mqtt &&
             hopScalingModule) {
             uint8_t hopCount = std::max(int8_t(0), getHopsAway(mp));

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -927,7 +927,11 @@ void NodeDB::installDefaultConfig(bool preserveKey = false)
     config.lora.override_frequency = USERPREFS_LORACONFIG_OVERRIDE_FREQUENCY;
 #endif
 
+#if USERPREFS_EVENT_MODE
+    config.lora.hop_limit = Default::eventModeHopLimit;
+#else
     config.lora.hop_limit = HOP_RELIABLE;
+#endif
 #ifdef USERPREFS_CONFIG_LORA_IGNORE_MQTT
     config.lora.ignore_mqtt = USERPREFS_CONFIG_LORA_IGNORE_MQTT;
 #else

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3237,6 +3237,11 @@ uint32_t sinceLastSeen(const meshtastic_NodeInfoLite *n)
 
 uint32_t sinceReceived(const meshtastic_MeshPacket *p)
 {
+    // rx_time may be a millis() placeholder while has_rx_time is false - don't age it as
+    // wall-clock, and don't pass it off as "just now" either.
+    if (!p->has_rx_time)
+        return SINCE_UNKNOWN;
+
     uint32_t now = getTime();
 
     int delta = (int)(now - p->rx_time);
@@ -3633,7 +3638,8 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
             return;
         }
 
-        if (mp.rx_time) // if the packet has a valid timestamp use it to update our last_heard
+        // Gate on has_rx_time, not truthiness - rx_time may hold a millis() placeholder.
+        if (mp.has_rx_time)
             info->last_heard = mp.rx_time;
 
         // Gate on the packet actually having been received over our own radio, not on rx_snr being

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -741,6 +741,10 @@ void NodeDB::resetRadioConfig(bool is_fresh_install)
         LOG_INFO("Set default channel and radio preferences!");
 
         channels.initDefaults();
+        // Defaults ship the public PSK, so strip it again before onConfigChanged() publishes hashes;
+        // loadFromDisk's sanitation is a no-op when the channel file was absent or corrupt.
+        if (owner.is_licensed)
+            channels.ensureLicensedOperation();
     }
 
     channels.onConfigChanged();

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -166,10 +166,15 @@ inline bool isRadioProfileFile(const char *filename)
            strcmp(filename, backupFileName) == 0;
 }
 
+/// "No trustworthy arrival time", as distinct from "zero seconds ago". Deliberately huge so the
+/// display formatters fall into their existing unknown-age branches ("unknown age" / "?").
+inline constexpr uint32_t SINCE_UNKNOWN = UINT32_MAX;
+
 /// Given a node, return how many seconds in the past (vs now) that we last heard from it
 uint32_t sinceLastSeen(const meshtastic_NodeInfoLite *n);
 
-/// Given a packet, return how many seconds in the past (vs now) it was received
+/// Given a packet, return how many seconds in the past (vs now) it was received,
+/// or SINCE_UNKNOWN if it carries no trustworthy rx_time.
 uint32_t sinceReceived(const meshtastic_MeshPacket *p);
 
 /// Outcome of mapping a single on-wire last-byte (next_hop / relay_node) back to a full NodeNum.

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -740,7 +740,12 @@ extern uint32_t error_address;
 #define NODEINFO_BITFIELD_HAS_IS_UNMESSAGABLE_MASK (1u << NODEINFO_BITFIELD_HAS_IS_UNMESSAGABLE_SHIFT)
 #define NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_SHIFT 9
 #define NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK (1u << NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_SHIFT)
-// Bits 10..31 reserved for future single-bit flags.
+// snr_q4 (persisted, sint32) is proto3 singular, so 0 == "never written", but 0 dB is valid.
+// This bit disambiguates: whenever snr_q4 is written from a genuine RF measurement.
+// Use this instead of `if (snr_q4)`. Legacy records (bit clear) are unambiguously "unknown".
+#define NODEINFO_BITFIELD_HAS_SNR_SHIFT 10
+#define NODEINFO_BITFIELD_HAS_SNR_MASK (1u << NODEINFO_BITFIELD_HAS_SNR_SHIFT)
+// Bits 11..31 reserved for future single-bit flags.
 
 // Convenience accessors so call sites read like the old struct fields.
 inline bool nodeInfoLiteHasUser(const meshtastic_NodeInfoLite *n)
@@ -782,6 +787,12 @@ inline bool nodeInfoLiteIsKeyManuallyVerified(const meshtastic_NodeInfoLite *n)
 inline bool nodeInfoLiteHasXeddsaSigned(const meshtastic_NodeInfoLite *n)
 {
     return n && (n->bitfield & NODEINFO_BITFIELD_HAS_XEDDSA_SIGNED_MASK);
+}
+/// True if this node's snr_q4 was written from a genuine RF measurement (including a real
+/// 0 dB reading). False means "never measured" - do not treat 0 as data.
+inline bool nodeInfoLiteHasSnr(const meshtastic_NodeInfoLite *n)
+{
+    return n && (n->bitfield & NODEINFO_BITFIELD_HAS_SNR_MASK);
 }
 /// A node that the eviction/migration paths must not drop: a favourite, an
 /// ignored (blocked) node, or a manually-verified key.

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1238,6 +1238,17 @@ void setReplayHopFields(meshtastic_MeshPacket &pkt, const meshtastic_NodeInfoLit
     pkt.hop_limit = hopsAway < hopLimit ? (uint8_t)(hopLimit - hopsAway) : 0;
 }
 
+/// 2020-01-01: a boot-relative counter needs ~50 years of uptime to reach this, so it cannot be
+/// confused with a real epoch.
+constexpr uint32_t MIN_PLAUSIBLE_EPOCH = 1577836800u;
+
+/// Not every last_heard writer gates on RTC quality - NodeDB::addFromContact stamps it with a bare
+/// getTime(), which is boot-relative seconds on a node that has never had a clock.
+bool lastHeardIsWallClock(const meshtastic_NodeInfoLite *header)
+{
+    return header && header->last_heard >= MIN_PLAUSIBLE_EPOCH;
+}
+
 } // namespace
 
 // Replayed packets deliberately leave rx_rssi absent. NodeInfoLite stores no RSSI, and
@@ -1258,6 +1269,8 @@ meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const mesh
     // fix time (which is often 0 and, when present, already round-trips inside the payload
     // via ConvertToPosition).
     pkt.rx_time = header ? header->last_heard : 0;
+    // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
+    pkt.has_rx_time = lastHeardIsWallClock(header);
     // Stable per-node/per-fix id: replaying the same unchanged history on every
     // reconnect must not look like a brand new packet to the phone's history/dedup.
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_POSITION_APP);
@@ -1285,6 +1298,8 @@ meshtastic_MeshPacket PhoneAPI::makeReplayTelemetryPacket(NodeNum num, const mes
     // No native timestamp on telemetry packets here; use last_heard.
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
+    // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
+    pkt.has_rx_time = lastHeardIsWallClock(header);
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_device_metrics_tag);
     pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
@@ -1391,6 +1406,8 @@ meshtastic_MeshPacket PhoneAPI::makeReplayEnvironmentPacket(uint32_t num, const 
     pkt.to = NODENUM_BROADCAST;
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
+    // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
+    pkt.has_rx_time = lastHeardIsWallClock(header);
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_environment_metrics_tag);
     pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
@@ -1456,6 +1473,8 @@ meshtastic_MeshPacket PhoneAPI::makeReplayStatusPacket(uint32_t num, const mesht
     // StatusMessage has no native timestamp; use last_heard.
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
+    // Present only when last_heard is a genuine epoch - see lastHeardIsWallClock().
+    pkt.has_rx_time = lastHeardIsWallClock(header);
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_NODE_STATUS_APP);
     pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1222,17 +1222,29 @@ uint32_t makeReplayPacketId(NodeNum num, uint32_t timestamp, uint32_t kind)
     return h ? h : 1; // some clients treat id 0 as "unset"
 }
 
-/// Populate hop_start/hop_limit from the node's real last-known hop count (if any) so a
-/// replayed packet doesn't read as "heard directly" when it wasn't.
+/// Populate hop_start/hop_limit from the node's last-known hop count - never fabricate one.
+/// hop_start == 0 with no decoded bitfield means unknown, not a direct neighbor; clients must
+/// treat it that way too (see hop_start in mesh.proto).
 void setReplayHopFields(meshtastic_MeshPacket &pkt, const meshtastic_NodeInfoLite *header)
 {
+    if (!header || !header->has_hops_away) {
+        pkt.hop_start = 0; // unknown - do not fabricate a direct-neighbor reading
+        pkt.hop_limit = 0;
+        return;
+    }
     uint8_t hopLimit = Default::getConfiguredOrDefaultHopLimit(config.lora.hop_limit);
-    uint8_t hopsAway = (header && header->has_hops_away) ? header->hops_away : 0;
+    uint8_t hopsAway = header->hops_away;
     pkt.hop_start = hopLimit;
     pkt.hop_limit = hopsAway < hopLimit ? (uint8_t)(hopLimit - hopsAway) : 0;
 }
+
 } // namespace
 
+// Replayed packets deliberately leave rx_rssi absent. NodeInfoLite stores no RSSI, and
+// rx_rssi has explicit presence on the wire, indicating "unknown".
+// Previously these packets carried a bare 0, which a client renders as a real reading.
+// Note the asymmetry with rx_snr below: that field is still proto3 singular, so "unknown" and
+//  "0 dB" remain indistinguishable there.
 meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const meshtastic_PositionLite &pos)
 {
     // Shape this exactly like a fresh live broadcast Position from the peer so the
@@ -1242,12 +1254,16 @@ meshtastic_MeshPacket PhoneAPI::makeReplayPositionPacket(NodeNum num, const mesh
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.from = num;
     pkt.to = NODENUM_BROADCAST;
-    pkt.rx_time = pos.time;
+    // rx_time means "when *we* received this" - use last_heard, not the position's own GPS
+    // fix time (which is often 0 and, when present, already round-trips inside the payload
+    // via ConvertToPosition).
+    pkt.rx_time = header ? header->last_heard : 0;
     // Stable per-node/per-fix id: replaying the same unchanged history on every
     // reconnect must not look like a brand new packet to the phone's history/dedup.
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_POSITION_APP);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated
@@ -1270,8 +1286,9 @@ meshtastic_MeshPacket PhoneAPI::makeReplayTelemetryPacket(NodeNum num, const mes
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_device_metrics_tag);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated - iOS client filters
@@ -1375,8 +1392,9 @@ meshtastic_MeshPacket PhoneAPI::makeReplayEnvironmentPacket(uint32_t num, const 
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_Telemetry_environment_metrics_tag);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated - iOS client filters
@@ -1439,8 +1457,9 @@ meshtastic_MeshPacket PhoneAPI::makeReplayStatusPacket(uint32_t num, const mesht
     const meshtastic_NodeInfoLite *header = nodeDB->getMeshNode(num);
     pkt.rx_time = header ? header->last_heard : 0;
     pkt.id = makeReplayPacketId(num, pkt.rx_time, meshtastic_PortNum_NODE_STATUS_APP);
-    pkt.channel = 0;
+    pkt.channel = header ? header->channel : 0;
     pkt.rx_snr = header ? header->snr : 0;
+    pkt.via_mqtt = nodeInfoLiteViaMqtt(header);
     setReplayHopFields(pkt, header);
     pkt.priority = meshtastic_MeshPacket_Priority_BACKGROUND;
     // Mark as if heard over the air, not internally generated - client filters

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -1855,7 +1855,12 @@ bool PhoneAPI::handleToRadioPacket(meshtastic_MeshPacket &p)
         p.want_ack = true;
     }
 
-    lastPortNumToRadio[p.decoded.portnum] = millis();
+    // Only the rate-limited ports above are ever read back, so recording any other portnum would let
+    // a client grow this map without bound by cycling through them.
+    if (IS_ONE_OF(p.decoded.portnum, meshtastic_PortNum_TRACEROUTE_APP, meshtastic_PortNum_POSITION_APP,
+                  meshtastic_PortNum_WAYPOINT_APP, meshtastic_PortNum_ALERT_APP, meshtastic_PortNum_TELEMETRY_APP,
+                  meshtastic_PortNum_TEXT_MESSAGE_APP))
+        lastPortNumToRadio[p.decoded.portnum] = millis();
     service->handleToRadio(p);
     return true;
 }

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -267,6 +267,7 @@ void RF95Interface::addReceiveMetadata(meshtastic_MeshPacket *mp)
 {
     mp->rx_snr = lora->getSNR();
     mp->rx_rssi = lround(lora->getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora->getFrequencyError());
 }
 

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -877,7 +877,7 @@ void printPacket(const char *prefix, const meshtastic_MeshPacket *p)
         out += DEBUG_PORT.mt_sprintf(" len=%d", p->encrypted.size + sizeof(PacketHeader));
     }
 
-    if (p->rx_time != 0)
+    if (p->has_rx_time) // rx_time has explicit presence; a millis() placeholder isn't a real reading to print
         out += DEBUG_PORT.mt_sprintf(" rxtime=%u", p->rx_time);
     if (p->rx_snr != 0.0)
         out += DEBUG_PORT.mt_sprintf(" rxSNR=%g", p->rx_snr);

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -881,7 +881,7 @@ void printPacket(const char *prefix, const meshtastic_MeshPacket *p)
         out += DEBUG_PORT.mt_sprintf(" rxtime=%u", p->rx_time);
     if (p->rx_snr != 0.0)
         out += DEBUG_PORT.mt_sprintf(" rxSNR=%g", p->rx_snr);
-    if (p->rx_rssi != 0)
+    if (p->has_rx_rssi) // rx_rssi has explicit presence; a != 0 check would hide a genuine 0 dBm reading
         out += DEBUG_PORT.mt_sprintf(" rxRSSI=%i", p->rx_rssi);
     if (p->via_mqtt != 0)
         out += DEBUG_PORT.mt_sprintf(" via MQTT");

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -5,6 +5,7 @@
 #include "MeshService.h"
 #include "NodeDB.h"
 #include "PositionPrecision.h"
+#include "UptimeClock.h"
 #include "gps/RTC.h"
 
 #include "configuration.h"
@@ -269,6 +270,19 @@ PacketId generatePacketId()
     return id;
 }
 
+RxTimeStamp computeRxTimeStamp()
+{
+    const bool haveTime = getRTCQuality() >= RTCQualityFromNet;
+    return {haveTime ? getValidTime(RTCQualityFromNet) : Time::getMillis(), haveTime};
+}
+
+void stampRxTime(meshtastic_MeshPacket *p)
+{
+    const RxTimeStamp ts = computeRxTimeStamp();
+    p->rx_time = ts.time;
+    p->has_rx_time = ts.valid;
+}
+
 meshtastic_MeshPacket *Router::allocForSending()
 {
     meshtastic_MeshPacket *p = packetPool.allocZeroed();
@@ -280,8 +294,8 @@ meshtastic_MeshPacket *Router::allocForSending()
     p->to = NODENUM_BROADCAST;
     p->hop_limit = Default::getConfiguredOrDefaultHopLimit(config.lora.hop_limit);
     p->id = generatePacketId();
-    p->rx_time =
-        getValidTime(RTCQualityFromNet); // Just in case we process the packet locally - make sure it has a valid timestamp
+    // Just in case we process the packet locally - make sure it has a timestamp.
+    stampRxTime(p);
 
     return p;
 }
@@ -1305,12 +1319,15 @@ void Router::dispatchReceived(meshtastic_MeshPacket *p, RxSource src)
     if (src == RX_SRC_RADIO)
         applyRoutingAuthCache(p);
 
-    // Also, we should set the time from the ISR and it should have msec level resolution.
     // Keep the decoded working packet and encrypted MQTT copy on the same local arrival timestamp.
-    const uint32_t rxTime = getValidTime(RTCQualityFromNet);
-    p->rx_time = rxTime;
-    if (p_encrypted)
-        p_encrypted->rx_time = rxTime;
+    // See computeRxTimeStamp() for the placeholder/has_rx_time semantics.
+    const RxTimeStamp rxStamp = computeRxTimeStamp();
+    p->rx_time = rxStamp.time;
+    p->has_rx_time = rxStamp.valid;
+    if (p_encrypted) {
+        p_encrypted->rx_time = rxStamp.time;
+        p_encrypted->has_rx_time = rxStamp.valid;
+    }
 
     // Take those raw bytes and convert them back into a well structured protobuf we can understand
     auto decodedState = perhapsDecode(p);
@@ -1443,7 +1460,8 @@ void Router::perhapsHandleReceived(meshtastic_MeshPacket *p)
 #if ARCH_PORTDUINO
     // Even ignored packets get logged in the trace
     if (portduino_config.traceFilename != "" || portduino_config.logoutputlevel == level_trace) {
-        p->rx_time = getValidTime(RTCQualityFromNet); // store the arrival timestamp for the phone
+        // Store the arrival timestamp for the phone before it's traced.
+        stampRxTime(p);
         LOG_TRACE("%s", MeshPacketSerializer::JsonSerializeEncrypted(p).c_str());
     }
 #endif

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -465,6 +465,8 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
 
     if (!(p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag ||
           p->which_payload_variant == meshtastic_MeshPacket_decoded_tag)) {
+        // Error returns from here own the packet, as the position-precision path below does.
+        packetPool.release(p);
         return meshtastic_Routing_Error_BAD_REQUEST;
     }
 
@@ -633,7 +635,9 @@ bool checkXeddsaReceivePolicy(meshtastic_MeshPacket *p)
     if (p->decoded.xeddsa_signature.size == XEDDSA_SIGNATURE_SIZE) {
         meshtastic_NodeInfoLite_public_key_t senderKey = {0, {0}};
         meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(p->from);
-        if (nodeDB->copyPublicKey(p->from, senderKey)) {
+        // Authoritative keys only: verifying against an opportunistic cache key would let a planted
+        // key mark its own node a signer, the trust loop #11116 closed on the decrypt path.
+        if (nodeDB->copyPublicKeyAuthoritative(p->from, senderKey)) {
             p->xeddsa_signed =
                 crypto->xeddsa_verify(senderKey.bytes, p->from, p->id, p->decoded.portnum, p->decoded.payload.bytes,
                                       p->decoded.payload.size, p->decoded.xeddsa_signature.bytes);

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -681,20 +681,14 @@ bool checkXeddsaReceivePolicy(meshtastic_MeshPacket *p)
         if (compatible)
             return true;
 
-        // In Balanced, preserve legacy unsigned-unicast compatibility and only reject the class a
-        // signing node always signs: a non-PKI broadcast whose signed encoding would still fit the
-        // LoRa frame. Canonical sizing removes unknown protobuf fields before mirroring the
-        // sender-side signedDataFits() gate, so this counts the same fields that gate counted.
-        // Unicast packets and broadcasts too big to carry a signature are never signed, so they
-        // must not be hard-failed here even for a known signer (PKI already returned above).
-        // isKnownXeddsaSigner consults the warm tier too: a signer evicted from the hot store
-        // must not become impersonatable via unsigned broadcasts until it is re-heard.
-        if (nodeDB->isKnownXeddsaSigner(p->from) && isBroadcast(p->to)) {
+        // Balanced rejects only what a signer always signs: non-PKI broadcasts whose signed encoding
+        // would have fit, plus unicasts on ham where licensed senders sign too. Mirrors perhapsEncode.
+        if (nodeDB->isKnownXeddsaSigner(p->from) && (isBroadcast(p->to) || owner.is_licensed)) {
             size_t canonicalSize;
             if (!canonicalSignableSize(&p->decoded, &canonicalSize))
                 return true; // can't size it; never drop on a sizing failure
             if (canonicalSize + XEDDSA_SIGNATURE_FIELD_BYTES + MESHTASTIC_HEADER_LENGTH <= MAX_LORA_PAYLOAD_LEN) {
-                LOG_WARN("Dropping unsigned broadcast from 0x%08x that previously signed", p->from);
+                LOG_WARN("Dropping unsigned packet from 0x%08x that previously signed", p->from);
                 return false;
             }
         }
@@ -1172,7 +1166,12 @@ meshtastic_Routing_Error perhapsEncode(meshtastic_MeshPacket *p)
                          *destKey.bytes);
                 return meshtastic_Routing_Error_PKI_FAILED;
             }
-            crypto->encryptCurve25519(p->to, getFrom(p), destKey, p->id, numbytes, bytes, p->encrypted.bytes);
+            // On failure encrypted.bytes holds no ciphertext, so continuing would put the plaintext
+            // on the air labelled pki_encrypted.
+            if (!crypto->encryptCurve25519(p->to, getFrom(p), destKey, p->id, numbytes, bytes, p->encrypted.bytes)) {
+                LOG_WARN("PKI encryption failed for destination node 0x%08x", p->to);
+                return meshtastic_Routing_Error_PKI_FAILED;
+            }
             numbytes += MESHTASTIC_PKC_OVERHEAD;
             p->channel = 0;
             p->pki_encrypted = true;

--- a/src/mesh/Router.h
+++ b/src/mesh/Router.h
@@ -10,6 +10,17 @@
 #include "concurrency/OSThread.h"
 #include <memory>
 
+/// rx_time/has_rx_time for "now": a real epoch when the clock is trustworthy, else a
+/// Time::getMillis() placeholder with valid=false.
+struct RxTimeStamp {
+    uint32_t time;
+    bool valid;
+};
+RxTimeStamp computeRxTimeStamp();
+
+/// Stamp p->rx_time/p->has_rx_time with computeRxTimeStamp().
+void stampRxTime(meshtastic_MeshPacket *p);
+
 /**
  * A mesh aware router that supports multiple interfaces.
  */

--- a/src/mesh/SX126xInterface.cpp
+++ b/src/mesh/SX126xInterface.cpp
@@ -335,6 +335,7 @@ template <typename T> void SX126xInterface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError());
 }
 

--- a/src/mesh/SX128xInterface.cpp
+++ b/src/mesh/SX128xInterface.cpp
@@ -205,6 +205,7 @@ template <typename T> void SX128xInterface<T>::addReceiveMetadata(meshtastic_Mes
     // LOG_DEBUG("PacketStatus %x", lora.getPacketStatus());
     mp->rx_snr = lora.getSNR();
     mp->rx_rssi = lround(lora.getRSSI());
+    mp->has_rx_rssi = true; // rx_rssi has explicit presence - a genuine reading must be marked present to survive encoding
     LOG_DEBUG("Corrected frequency offset: %f", lora.getFrequencyError());
 }
 

--- a/src/mesh/TypeConversions.cpp
+++ b/src/mesh/TypeConversions.cpp
@@ -10,6 +10,9 @@ meshtastic_NodeInfo TypeConversions::ConvertToNodeInfo(const meshtastic_NodeInfo
     meshtastic_NodeInfo info = meshtastic_NodeInfo_init_default;
 
     info.num = lite->num;
+    // NodeInfo.snr (wire) is still proto3 singular float - unlike NodeInfoLite.snr_q4, it has no
+    // presence bit and cannot distinguish a genuine 0 dB from "unknown". nodeInfoLiteHasSnr(lite)
+    // is available if a future NodeInfo revision needs to carry that distinction to clients.
     info.snr = lite->snr;
     info.last_heard = lite->last_heard;
     info.channel = lite->channel;

--- a/src/mesh/generated/meshtastic/deviceonly.pb.h
+++ b/src/mesh/generated/meshtastic/deviceonly.pb.h
@@ -95,8 +95,11 @@ typedef struct _meshtastic_NodeInfoLite {
     /* The public key of the user's device, for PKI-based encrypted DMs. */
     meshtastic_NodeInfoLite_public_key_t public_key;
     /* Q4-encoded SNR: dB × 4, sint32 zigzag. Matches RouteDiscovery convention.
- Encode: snr_q4 = (int32_t)(snr * 4.0f). Decode: snr = snr_q4 / 4.0f.
- float snr is always zeroed on disk; this field carries all persisted SNR. */
+ Encode: snr_q4 = (int32_t)lroundf(snr * 4.0f). Decode: snr = snr_q4 / 4.0f.
+ float snr is always zeroed on disk; this field carries all persisted SNR.
+ A stored 0 does not by itself mean "unknown" here - see NODEINFO_BITFIELD_HAS_SNR in
+ src/mesh/NodeDB.h for the presence bit that disambiguates a genuine 0 dB reading from
+ "never measured". */
     int32_t snr_q4;
 } meshtastic_NodeInfoLite;
 

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1103,14 +1103,24 @@ typedef struct _meshtastic_MeshPacket {
     /* The priority of this message for sending.
  See MeshPacket.Priority description for more details. */
     meshtastic_MeshPacket_Priority priority;
-    /* rssi of received packet. Only sent to phone for dispay purposes. */
+    /* rssi of received packet. Only sent to phone for dispay purposes.
+ Explicit presence: rssi 0 is a legitimate reading on some radios (SX126x can report exactly
+ 0 dBm; SX127x's formula can even go positive), so implicit-presence proto3 made an unset
+ value indistinguishable from a measured one. has_rx_rssi disambiguates; a replayed packet
+ built from history the device never restored an RSSI for should leave this field absent
+ rather than emitting 0. */
+    bool has_rx_rssi;
     int32_t rx_rssi;
     /* Describe if this message is delayed */
     meshtastic_MeshPacket_Delayed delayed;
     /* Describes whether this packet passed via MQTT somewhere along the path it currently took. */
     bool via_mqtt;
     /* Hop limit with which the original packet started. Sent via LoRa using three bits in the unencrypted header.
- When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled. */
+ When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled.
+ hop_start == 0 does not necessarily mean a direct (0-hop) neighbor: firmware prior to 2.3.0
+ never populated this field, so a receiver can only trust hop_start == 0 as genuine once it has
+ decoded the packet and confirmed the sender's bitfield is present (added in 2.5.0). Until then,
+ or for a sender that never sets that bitfield, treat hop_start == 0 as unknown, not direct. */
     uint8_t hop_start;
     /* Records the public key the packet was encrypted with, if applicable. */
     meshtastic_MeshPacket_public_key_t public_key;
@@ -1730,7 +1740,7 @@ extern "C" {
 #define meshtastic_Waypoint_init_default         {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_default, 0, 0, 0}
 #define meshtastic_StatusMessage_init_default    {""}
 #define meshtastic_MqttClientProxyMessage_init_default {"", 0, {{0, {0}}}, 0}
-#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_default         {0, false, meshtastic_User_init_default, false, meshtastic_Position_init_default, 0, 0, false, meshtastic_DeviceMetrics_init_default, 0, 0, false, 0, 0, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_default       {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_default        {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -1769,7 +1779,7 @@ extern "C" {
 #define meshtastic_Waypoint_init_zero            {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_zero, 0, 0, 0}
 #define meshtastic_StatusMessage_init_zero       {""}
 #define meshtastic_MqttClientProxyMessage_init_zero {"", 0, {{0, {0}}}, 0}
-#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_zero            {0, false, meshtastic_User_init_zero, false, meshtastic_Position_init_zero, 0, 0, false, meshtastic_DeviceMetrics_init_zero, 0, 0, false, 0, 0, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_zero          {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_zero           {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -2194,7 +2204,7 @@ X(a, STATIC,   SINGULAR, FLOAT,    rx_snr,            8) \
 X(a, STATIC,   SINGULAR, UINT32,   hop_limit,         9) \
 X(a, STATIC,   SINGULAR, BOOL,     want_ack,         10) \
 X(a, STATIC,   SINGULAR, UENUM,    priority,         11) \
-X(a, STATIC,   SINGULAR, INT32,    rx_rssi,          12) \
+X(a, STATIC,   OPTIONAL, INT32,    rx_rssi,          12) \
 X(a, STATIC,   SINGULAR, UENUM,    delayed,          13) \
 X(a, STATIC,   SINGULAR, BOOL,     via_mqtt,         14) \
 X(a, STATIC,   SINGULAR, UINT32,   hop_start,        15) \

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1079,7 +1079,14 @@ typedef struct _meshtastic_MeshPacket {
     /* The time this message was received by the esp32 (secs since 1970).
  Note: this field is _never_ sent on the radio link itself (to save space) Times
  are typically not sent over the mesh, but they will be added to any Packet
- (chain of SubPacket) sent to the phone (so the phone can know exact time of reception) */
+ (chain of SubPacket) sent to the phone (so the phone can know exact time of reception)
+ Explicit presence: firmware cannot always attach a trustworthy wall-clock timestamp at the
+ moment of reception - a node with no GPS and no phone connected yet has no time source at
+ all. has_rx_time disambiguates that state from a genuine (if coincidental) 1970-01-01
+ reading. A packet delivered with this field absent may still be re-timestamped once a valid
+ clock becomes available, before the phone ever sees it - "absent" is not guaranteed
+ permanent, only "not yet known at last observation". */
+    bool has_rx_time;
     uint32_t rx_time;
     /* *Never* sent over the radio links.
  Set during reception to indicate the SNR of this packet.
@@ -1740,7 +1747,7 @@ extern "C" {
 #define meshtastic_Waypoint_init_default         {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_default, 0, 0, 0}
 #define meshtastic_StatusMessage_init_default    {""}
 #define meshtastic_MqttClientProxyMessage_init_default {"", 0, {{0, {0}}}, 0}
-#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, false, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_default         {0, false, meshtastic_User_init_default, false, meshtastic_Position_init_default, 0, 0, false, meshtastic_DeviceMetrics_init_default, 0, 0, false, 0, 0, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_default       {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_default        {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -1779,7 +1786,7 @@ extern "C" {
 #define meshtastic_Waypoint_init_zero            {0, false, 0, false, 0, 0, 0, "", "", 0, 0, false, meshtastic_BoundingBox_init_zero, 0, 0, 0}
 #define meshtastic_StatusMessage_init_zero       {""}
 #define meshtastic_MqttClientProxyMessage_init_zero {"", 0, {{0, {0}}}, 0}
-#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, false, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, false, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
 #define meshtastic_NodeInfo_init_zero            {0, false, meshtastic_User_init_zero, false, meshtastic_Position_init_zero, 0, 0, false, meshtastic_DeviceMetrics_init_zero, 0, 0, false, 0, 0, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_zero          {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_zero           {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -2199,7 +2206,7 @@ X(a, STATIC,   SINGULAR, UINT32,   channel,           3) \
 X(a, STATIC,   ONEOF,    MESSAGE,  (payload_variant,decoded,decoded),   4) \
 X(a, STATIC,   ONEOF,    BYTES,    (payload_variant,encrypted,encrypted),   5) \
 X(a, STATIC,   SINGULAR, FIXED32,  id,                6) \
-X(a, STATIC,   SINGULAR, FIXED32,  rx_time,           7) \
+X(a, STATIC,   OPTIONAL, FIXED32,  rx_time,           7) \
 X(a, STATIC,   SINGULAR, FLOAT,    rx_snr,            8) \
 X(a, STATIC,   SINGULAR, UINT32,   hop_limit,         9) \
 X(a, STATIC,   SINGULAR, BOOL,     want_ack,         10) \

--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -79,6 +79,11 @@ class UdpMulticastHandler final
                 LOG_WARN("UDP packet with spoofed local from=0x%08x, dropping", mp.from);
                 return;
             }
+            // Same clamp the MQTT ingress applies: an out-of-range hop count is not relayable.
+            if (mp.hop_limit > HOP_MAX || mp.hop_start > HOP_MAX) {
+                LOG_WARN("UDP packet with invalid hop_limit(%u) or hop_start(%u), dropping", mp.hop_limit, mp.hop_start);
+                return;
+            }
             mp.transport_mechanism = meshtastic_MeshPacket_TransportMechanism_TRANSPORT_MULTICAST_UDP;
             // Authentication metadata is local-only; Router re-establishes it after successful PKI decryption.
             mp.pki_encrypted = false;

--- a/src/mesh/udp/UdpMulticastHandler.h
+++ b/src/mesh/udp/UdpMulticastHandler.h
@@ -86,9 +86,13 @@ class UdpMulticastHandler final
             UniquePacketPoolPacket p = packetPool.allocUniqueCopy(mp);
             if (!p)
                 return;
-            // Unset received SNR/RSSI
+            // Unset received SNR/RSSI - no local RF measurement exists for a UDP arrival. rx_rssi
+            // has explicit presence, so also clear has_rx_rssi: `mp` may have arrived already
+            // carrying a real measurement from whichever node forwarded it onto UDP, and leaving
+            // the presence bit set would misrepresent that stale value as "0 dBm over UDP".
             p->rx_snr = 0;
             p->rx_rssi = 0;
+            p->has_rx_rssi = false;
             router->enqueueReceivedMessage(p.release());
         }
     }

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -10,6 +10,7 @@
 #include "SPILock.h"
 #include "gps/RTC.h"
 #include "input/InputBroker.h"
+#include "mesh/mesh-pb-constants.h"
 #include "meshUtils.h"
 #include <ErriezCRC32.h>
 #include <FSCommon.h>
@@ -70,6 +71,10 @@
 
 AdminModule *adminModule;
 
+#ifdef PIO_UNIT_TESTING
+uint32_t disableBluetoothCallCountForTest = 0;
+#endif
+
 #if !(MESHTASTIC_EXCLUDE_PKI_KEYGEN || MESHTASTIC_EXCLUDE_PKI)
 static bool licensedIdentityWillMigrate()
 {
@@ -92,6 +97,27 @@ static void writeSecret(char *buf, size_t bufsz, const char *currentVal)
     if (strcmp(buf, secretReserved) == 0) {
         strncpy(buf, currentVal, bufsz);
     }
+}
+
+template <size_t MaxSize> static NOINLINE bool protobufsEqual(const pb_msgdesc_t *fields, const void *left, const void *right)
+{
+    uint8_t leftBytes[MaxSize], rightBytes[MaxSize];
+    const size_t leftSize = pb_encode_to_bytes(leftBytes, sizeof(leftBytes), fields, left);
+    const size_t rightSize = pb_encode_to_bytes(rightBytes, sizeof(rightBytes), fields, right);
+    return leftSize == rightSize && memcmp(leftBytes, rightBytes, leftSize) == 0;
+}
+
+static NOINLINE bool loraRadioConfigChanged(const meshtastic_Config_LoRaConfig &oldConfig,
+                                            const meshtastic_Config_LoRaConfig &newConfig)
+{
+    auto oldEffective = oldConfig;
+    auto newEffective = newConfig;
+    if (oldEffective.use_preset && newEffective.use_preset) {
+        oldEffective.bandwidth = newEffective.bandwidth = 0;
+        oldEffective.spread_factor = newEffective.spread_factor = 0;
+        oldEffective.coding_rate = newEffective.coding_rate = 0;
+    }
+    return !protobufsEqual<meshtastic_Config_LoRaConfig_size>(&meshtastic_Config_LoRaConfig_msg, &oldEffective, &newEffective);
 }
 
 /**
@@ -482,14 +508,16 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     }
     case meshtastic_AdminMessage_begin_edit_settings_tag: {
         LOG_INFO("Begin transaction for editing settings");
+        if (!hasOpenEditTransaction) {
+            deferredEditSegments = 0;
+            deferredShouldReboot = false;
+            deferredRadioAffected = false;
+        }
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
-        deferredShouldReboot = false;
-        deferredRadioAffected = false;
         break;
     }
     case meshtastic_AdminMessage_commit_edit_settings_tag: {
-        disableBluetooth();
         LOG_INFO("Commit transaction for edited settings");
         hasOpenEditTransaction = false;
         deferredEditSegments = 0;
@@ -498,6 +526,8 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         const bool commitReboot = deferredShouldReboot, commitRadio = deferredRadioAffected;
         deferredShouldReboot = false;
         deferredRadioAffected = false;
+        if (commitReboot)
+            disableBluetooth();
         saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE,
                     commitReboot, commitRadio);
         flushChannelWarnings(); // one coalesced message for everything edited in this transaction
@@ -1030,13 +1060,12 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
     case meshtastic_Config_network_tag: {
         LOG_INFO("Set config: WiFi");
         config.has_network = true;
+        auto incoming = c.payload_variant.network;
+        writeSecret(incoming.wifi_psk, sizeof(incoming.wifi_psk), config.network.wifi_psk);
         // No-op set must not reboot; any real change still restarts the network stack. memcmp fails safe.
-        if (memcmp(&config.network, &c.payload_variant.network, sizeof(config.network)) == 0)
+        if (memcmp(&config.network, &incoming, sizeof(config.network)) == 0)
             requiresReboot = false;
-        char prevPsk[sizeof(config.network.wifi_psk)];
-        memcpy(prevPsk, config.network.wifi_psk, sizeof(prevPsk));
-        config.network = c.payload_variant.network;
-        writeSecret(config.network.wifi_psk, sizeof(config.network.wifi_psk), prevPsk);
+        config.network = incoming;
         break;
     }
     case meshtastic_Config_display_tag:
@@ -1066,7 +1095,6 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 
         LOG_INFO("Set config: LoRa");
         config.has_lora = true;
-        radioAffected = true; // the only sub-message that legitimately needs a live radio reconfigure
 
         if (validatedLora.coding_rate != clampCodingRate(validatedLora.coding_rate)) {
             LOG_WARN("Invalid coding_rate %d, setting to %d", validatedLora.coding_rate, LORA_CR_DEFAULT);
@@ -1213,6 +1241,7 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
         }
 #endif
 
+        radioAffected = loraRadioConfigChanged(oldLoraConfig, validatedLora);
         config.lora = validatedLora; // Finally, return the validated config back to the main config
         if (validatedLora.modem_preset != oldLoraConfig.modem_preset) {
             pendingOldLora = oldLoraConfig;
@@ -1513,6 +1542,10 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 
 void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
 {
+    const ChannelIndex oldPrimaryIndex = channels.getPrimaryIndex();
+    char oldPrimaryName[32];
+    snprintf(oldPrimaryName, sizeof(oldPrimaryName), "%s", channels.getName(oldPrimaryIndex));
+
     channels.setChannel(cc);
     if (channels.ensureLicensedOperation()) {
         warnLicensedMode();
@@ -1537,8 +1570,11 @@ void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
     }
     if (clamped)
         sendWarning(publicChannelPrecisionMessage);
-    saveChanges(SEGMENT_CHANNELS, false, /*radioAffected=*/true); // real frequency-slot / PSK change
-    warnOnChannelSet(channels.getByIndex(cc.index));              // passes the saved channel
+    const ChannelIndex newPrimaryIndex = channels.getPrimaryIndex();
+    const bool radioAffected =
+        oldPrimaryIndex != newPrimaryIndex || strcmp(oldPrimaryName, channels.getName(newPrimaryIndex)) != 0;
+    saveChanges(SEGMENT_CHANNELS, false, radioAffected);
+    warnOnChannelSet(channels.getByIndex(cc.index)); // passes the saved channel
     // Inside an edit transaction the queued warnings are flushed once at commit; otherwise emit now.
     if (!hasOpenEditTransaction)
         flushChannelWarnings();
@@ -2567,6 +2603,9 @@ void AdminModule::warnOnLoraPresetChange(const meshtastic_Config_LoRaConfig &old
 
 void disableBluetooth()
 {
+#ifdef PIO_UNIT_TESTING
+    disableBluetoothCallCountForTest++;
+#endif
 #if HAS_BLUETOOTH
 #ifdef ARCH_ESP32
     if (nimbleBluetooth)

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -117,6 +117,14 @@ static NOINLINE bool loraRadioConfigChanged(const meshtastic_Config_LoRaConfig &
         oldEffective.spread_factor = newEffective.spread_factor = 0;
         oldEffective.coding_rate = newEffective.coding_rate = 0;
     }
+    newEffective.hop_limit = oldEffective.hop_limit;
+    newEffective.tx_enabled = oldEffective.tx_enabled;
+    newEffective.override_duty_cycle = oldEffective.override_duty_cycle;
+    newEffective.pa_fan_disabled = oldEffective.pa_fan_disabled;
+    newEffective.ignore_incoming_count = oldEffective.ignore_incoming_count;
+    memcpy(newEffective.ignore_incoming, oldEffective.ignore_incoming, sizeof(newEffective.ignore_incoming));
+    newEffective.ignore_mqtt = oldEffective.ignore_mqtt;
+    newEffective.config_ok_to_mqtt = oldEffective.config_ok_to_mqtt;
     return !protobufsEqual<meshtastic_Config_LoRaConfig_size>(&meshtastic_Config_LoRaConfig_msg, &oldEffective, &newEffective);
 }
 
@@ -1333,12 +1341,6 @@ void AdminModule::handleSetConfig(const meshtastic_Config &c, bool fromOthers)
 bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
 {
     bool shouldReboot = true;
-    // If we are in an open transaction or configuring MQTT or Serial (which have validation), defer disabling Bluetooth
-    // Otherwise, disable Bluetooth to prevent the phone from interfering with the config
-    if (!hasOpenEditTransaction && !IS_ONE_OF(c.which_payload_variant, meshtastic_ModuleConfig_mqtt_tag,
-                                              meshtastic_ModuleConfig_serial_tag, meshtastic_ModuleConfig_statusmessage_tag)) {
-        disableBluetooth();
-    }
 
     switch (c.which_payload_variant) {
     case meshtastic_ModuleConfig_mqtt_tag:
@@ -1350,14 +1352,13 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
         if (!MQTT::isValidConfig(c.payload_variant.mqtt)) {
             return false;
         }
-        // Disable Bluetooth to prevent interference during MQTT configuration
-        disableBluetooth();
         moduleConfig.has_mqtt = true;
         {
-            char prevPass[sizeof(moduleConfig.mqtt.password)];
-            memcpy(prevPass, moduleConfig.mqtt.password, sizeof(prevPass));
-            moduleConfig.mqtt = c.payload_variant.mqtt;
-            writeSecret(moduleConfig.mqtt.password, sizeof(moduleConfig.mqtt.password), prevPass);
+            auto incoming = c.payload_variant.mqtt;
+            writeSecret(incoming.password, sizeof(incoming.password), moduleConfig.mqtt.password);
+            shouldReboot = !protobufsEqual<meshtastic_ModuleConfig_MQTTConfig_size>(&meshtastic_ModuleConfig_MQTTConfig_msg,
+                                                                                    &moduleConfig.mqtt, &incoming);
+            moduleConfig.mqtt = incoming;
         }
 #endif
         break;
@@ -1369,9 +1370,10 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
             LOG_ERROR("Invalid serial config");
             return false;
         }
-        disableBluetooth(); // Disable Bluetooth to prevent interference during Serial configuration
 #endif
         moduleConfig.has_serial = true;
+        shouldReboot = !protobufsEqual<meshtastic_ModuleConfig_SerialConfig_size>(
+            &meshtastic_ModuleConfig_SerialConfig_msg, &moduleConfig.serial, &c.payload_variant.serial);
         moduleConfig.serial = c.payload_variant.serial;
         break;
     case meshtastic_ModuleConfig_external_notification_tag:
@@ -1535,6 +1537,8 @@ bool AdminModule::handleSetModuleConfig(const meshtastic_ModuleConfig &c)
     }
 #endif
     }
+    if (shouldReboot && !hasOpenEditTransaction)
+        disableBluetooth();
     // No module config feeds RadioInterface::reconfigure() - that reads config.lora only.
     saveChanges(SEGMENT_MODULECONFIG, shouldReboot, /*radioAffected=*/false);
     return true;
@@ -1571,8 +1575,10 @@ void AdminModule::handleSetChannel(const meshtastic_Channel &cc)
     if (clamped)
         sendWarning(publicChannelPrecisionMessage);
     const ChannelIndex newPrimaryIndex = channels.getPrimaryIndex();
-    const bool radioAffected =
-        oldPrimaryIndex != newPrimaryIndex || strcmp(oldPrimaryName, channels.getName(newPrimaryIndex)) != 0;
+    const bool usesChannelNameForFrequency = config.lora.override_frequency == 0 && RadioInterface::uses_default_frequency_slot &&
+                                             getRegion(config.lora.region)->overrideSlot == OVERRIDE_SLOT_DEFAULT_CHANNEL_HASH;
+    const bool radioAffected = usesChannelNameForFrequency && (oldPrimaryIndex != newPrimaryIndex ||
+                                                               strcmp(oldPrimaryName, channels.getName(newPrimaryIndex)) != 0);
     saveChanges(SEGMENT_CHANNELS, false, radioAffected);
     warnOnChannelSet(channels.getByIndex(cc.index)); // passes the saved channel
     // Inside an edit transaction the queued warnings are flushed once at commit; otherwise emit now.
@@ -1991,13 +1997,24 @@ void AdminModule::expireStaleEditTransaction()
     deferredEditSegments = 0;
     // Same consume-and-clear as a real commit: an abandoned transaction must not leave its
     // decisions behind for the next one.
-    const bool expiredRadio = deferredRadioAffected;
+    const bool expiredReboot = deferredShouldReboot, expiredRadio = deferredRadioAffected;
     deferredShouldReboot = false;
     deferredRadioAffected = false;
-    // No reboot: the settings are already live in RAM and the client that would expect one is gone.
+    if (expiredReboot)
+        disableBluetooth();
     if (segments)
-        saveChanges(segments, false, expiredRadio);
+        saveChanges(segments, expiredReboot, expiredRadio);
     flushChannelWarnings();
+}
+
+int32_t AdminModule::runOnce()
+{
+    expireStaleEditTransaction();
+    if (!hasOpenEditTransaction)
+        return EDIT_TRANSACTION_IDLE_MS;
+
+    const uint32_t elapsed = millis() - editTransactionActivityMs;
+    return elapsed < EDIT_TRANSACTION_IDLE_MS ? EDIT_TRANSACTION_IDLE_MS - elapsed : 1;
 }
 
 // radioAffected is mandatory here - see the note on the declaration in AdminModule.h for why it
@@ -2016,6 +2033,7 @@ void AdminModule::saveChanges(int saveWhat, bool shouldReboot, bool radioAffecte
         deferredRadioAffected |= radioAffected;
         LOG_INFO("Delay save of changes to disk until the open transaction is committed");
         editTransactionActivityMs = millis(); // still in use, so not the abandoned kind we time out
+        setIntervalFromNow(EDIT_TRANSACTION_IDLE_MS);
         deferredEditSegments |= saveWhat;
         return;
     }
@@ -2096,7 +2114,9 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
                 /*radioAffected=*/true);
 }
 
-AdminModule::AdminModule() : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_APP, &meshtastic_AdminMessage_msg)
+AdminModule::AdminModule()
+    : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_APP, &meshtastic_AdminMessage_msg),
+      concurrency::OSThread("AdminTimeout", EDIT_TRANSACTION_IDLE_MS)
 {
     // restrict to the admin channel for rx
     // boundChannel = Channels::adminChannel;

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -523,6 +523,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         }
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
+        setIntervalFromNow(EDIT_TRANSACTION_IDLE_MS);
         break;
     }
     case meshtastic_AdminMessage_commit_edit_settings_tag: {
@@ -534,6 +535,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
         const bool commitReboot = deferredShouldReboot, commitRadio = deferredRadioAffected;
         deferredShouldReboot = false;
         deferredRadioAffected = false;
+        setIntervalFromNow(INT32_MAX);
         if (commitReboot)
             disableBluetooth();
         saveChanges(SEGMENT_CONFIG | SEGMENT_MODULECONFIG | SEGMENT_DEVICESTATE | SEGMENT_CHANNELS | SEGMENT_NODEDATABASE,
@@ -2000,6 +2002,7 @@ void AdminModule::expireStaleEditTransaction()
     const bool expiredReboot = deferredShouldReboot, expiredRadio = deferredRadioAffected;
     deferredShouldReboot = false;
     deferredRadioAffected = false;
+    setIntervalFromNow(INT32_MAX);
     if (expiredReboot)
         disableBluetooth();
     if (segments)
@@ -2011,7 +2014,7 @@ int32_t AdminModule::runOnce()
 {
     expireStaleEditTransaction();
     if (!hasOpenEditTransaction)
-        return EDIT_TRANSACTION_IDLE_MS;
+        return INT32_MAX;
 
     const uint32_t elapsed = millis() - editTransactionActivityMs;
     return elapsed < EDIT_TRANSACTION_IDLE_MS ? EDIT_TRANSACTION_IDLE_MS - elapsed : 1;
@@ -2116,7 +2119,7 @@ void AdminModule::handleSetHamMode(const meshtastic_HamParameters &p)
 
 AdminModule::AdminModule()
     : ProtobufModule("Admin", meshtastic_PortNum_ADMIN_APP, &meshtastic_AdminMessage_msg),
-      concurrency::OSThread("AdminTimeout", EDIT_TRANSACTION_IDLE_MS)
+      concurrency::OSThread("AdminTimeout", INT32_MAX)
 {
     // restrict to the admin channel for rx
     // boundChannel = Channels::adminChannel;

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -3,6 +3,7 @@
 #include <esp_ota_ops.h>
 #endif
 #include "ProtobufModule.h"
+#include "concurrency/OSThread.h"
 #include "meshUtils.h"
 #include <sys/types.h>
 #if HAS_WIFI
@@ -21,7 +22,9 @@ struct AdminModule_ObserverData {
 /**
  * Admin module for admin messages
  */
-class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Observable<AdminModule_ObserverData *>
+class AdminModule : public ProtobufModule<meshtastic_AdminMessage>,
+                    public Observable<AdminModule_ObserverData *>,
+                    private concurrency::OSThread
 {
     friend class AdminModuleTestShim; // test/support/AdminModuleTestShim.h - native tests reach the private handlers/state
 
@@ -37,6 +40,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Obser
     @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
     */
     virtual bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_AdminMessage *p) override;
+    virtual int32_t runOnce() override;
 
   private:
     bool hasOpenEditTransaction = false;

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -53,6 +53,7 @@ class AdminModule : public ProtobufModule<meshtastic_AdminMessage>,
     void expireStaleEditTransaction();
 #ifdef PIO_UNIT_TESTING
     int lastSaveWhatForTest = 0;
+    unsigned long editTransactionTimerIntervalForTest() const { return interval; }
 #endif
 
     // While a transaction is open, saveChanges() defers the write - so the per-field reboot and

--- a/src/modules/DropzoneModule.cpp
+++ b/src/modules/DropzoneModule.cpp
@@ -32,14 +32,17 @@ ProcessMessage DropzoneModule::handleReceived(const meshtastic_MeshPacket &mp)
     auto &p = mp.decoded;
     char matchCompare[54];
     auto incomingMessage = reinterpret_cast<const char *>(p.payload.bytes);
-    sprintf(matchCompare, "%s conditions", owner.short_name);
-    if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
+    // payload.bytes is not NUL-terminated, so a comparison longer than the received size would read
+    // whatever the previous occupant of the packet left behind.
+    const size_t received = p.payload.size;
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.short_name);
+    if (received >= strlen(matchCompare) && strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
     }
 
-    sprintf(matchCompare, "%s conditions", owner.long_name);
-    if (strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
+    snprintf(matchCompare, sizeof(matchCompare), "%s conditions", owner.long_name);
+    if (received >= strlen(matchCompare) && strncasecmp(incomingMessage, matchCompare, strlen(matchCompare)) == 0) {
         LOG_DEBUG("Received dropzone conditions request");
         startSendConditions = millis();
     }

--- a/src/modules/ExternalNotificationModule.h
+++ b/src/modules/ExternalNotificationModule.h
@@ -23,7 +23,7 @@ extern AmbientLightingThread *ambientLightingThread;
 #endif
 #endif
 
-#if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL) && !defined(CONFIG_IDF_TARGET_ESP32C6)
+#if !defined(ARCH_PORTDUINO) && !defined(ARCH_STM32WL)
 #include <NonBlockingRtttl.h>
 #else
 // Noop class for portduino.

--- a/src/modules/MeshBeaconModule.cpp
+++ b/src/modules/MeshBeaconModule.cpp
@@ -342,7 +342,7 @@ void MeshBeaconBroadcastModule::sendBeacon()
         p->hop_limit = 0; // all beacon packets are zero hopped to limit spamming.
         p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
         p->want_ack = false;
-        p->rx_time = getValidTime(RTCQualityFromNet);
+        stampRxTime(p);
     };
 
     // ── Packet type decisions ────────────────────────────────────────────────

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -53,10 +53,9 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
         return true;
     }
     NodeNum sourceNum = getFrom(&mp);
-    const meshtastic_NodeInfoLite *node = nodeDB->getMeshNode(sourceNum);
-    // Broadcasts only: senders never sign unicast NodeInfo, so dropping it would break exchanges
-    // with signer nodes. Backstops ingress that skips Router's downgrade drop (e.g. decoded MQTT).
-    if (node && nodeInfoLiteHasXeddsaSigned(node) && !mp.xeddsa_signed && isBroadcast(mp.to)) {
+    // Broadcasts only: unicast NodeInfo is unsigned off ham, so updateUser refuses the identity
+    // write instead. isKnownXeddsaSigner also covers the warm tier.
+    if (nodeDB->isKnownXeddsaSigner(sourceNum) && !mp.xeddsa_signed && isBroadcast(mp.to)) {
         LOG_WARN("Dropping unsigned NodeInfo broadcast from node 0x%08x that previously signed", sourceNum);
         return true;
     }

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -5,6 +5,7 @@
 #include "NodeStatus.h"
 #include "Router.h"
 #include "TransmitHistory.h"
+#include "UptimeClock.h"
 #include "configuration.h"
 #include "gps/RTC.h"
 #include "main.h"
@@ -33,7 +34,9 @@ bool NodeInfoModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, mes
     // Suppress replies to senders we've replied to recently (12H window)
     if (mp.decoded.want_response && !isFromUs(&mp)) {
         const NodeNum sender = getFrom(&mp);
-        const uint32_t now = mp.rx_time ? mp.rx_time : getTime();
+        // A local dedup window, not a wall-clock reading - uptime avoids RTC-quality jumps and
+        // replayed packets' stale rx_time perturbing it.
+        const uint32_t now = (uint32_t)(Time::getMillis64() / 1000);
         auto it = lastNodeInfoSeen.find(sender);
         if (it != lastNodeInfoSeen.end()) {
             uint32_t sinceLast = now >= it->second ? now - it->second : 0;

--- a/src/modules/PositionModule.cpp
+++ b/src/modules/PositionModule.cpp
@@ -167,9 +167,9 @@ bool PositionModule::hasGPS()
 }
 
 // Allocate a packet with our position data if we have one
-meshtastic_MeshPacket *PositionModule::allocPositionPacket()
+meshtastic_MeshPacket *PositionModule::allocPositionPacket(uint32_t atPrecision)
 {
-    if (precision == 0) {
+    if (atPrecision == 0) {
         LOG_DEBUG("Skip location send because precision is set to 0!");
         return nullptr;
     }
@@ -196,12 +196,12 @@ meshtastic_MeshPacket *PositionModule::allocPositionPacket()
     }
 
     // lat/lon are unconditionally included - IF AVAILABLE!
-    LOG_DEBUG("Send location with precision %i", precision);
+    LOG_DEBUG("Send location with precision %i", atPrecision);
     p.latitude_i = localPosition.latitude_i;
     p.longitude_i = localPosition.longitude_i;
     p.has_latitude_i = true;
     p.has_longitude_i = true;
-    applyPositionPrecision(p, precision);
+    applyPositionPrecision(p, atPrecision);
     // Always use NTP / GPS time if available
     if (getValidTime(RTCQualityNTP) > 0) {
         p.time = getValidTime(RTCQualityNTP);
@@ -281,7 +281,7 @@ meshtastic_MeshPacket *PositionModule::allocReply()
         return nullptr;
     }
 
-    meshtastic_MeshPacket *reply = allocPositionPacket();
+    meshtastic_MeshPacket *reply = allocPositionPacket(precision);
     if (reply) {
         lastSentReply = millis(); // Track when we sent this reply
     }
@@ -373,13 +373,34 @@ void PositionModule::sendOurPosition()
     currentGeneration = radioGeneration;
 
     // If we changed channels, ask everyone else for their latest info
-    LOG_INFO("Send pos@%x:6 to mesh (wantReplies=%d)", localPosition.timestamp, requestReplies);
     for (uint8_t channelNum = 0; channelNum < 8; channelNum++) {
         if (getPositionPrecisionForChannel(channelNum) != 0) {
+            LOG_INFO("Send pos@%x:6 to mesh (wantReplies=%d)", localPosition.timestamp, requestReplies);
             sendOurPosition(NODENUM_BROADCAST, requestReplies, channelNum);
             return;
         }
     }
+    LOG_INFO("Skip pos@%x:6 broadcast; position sharing is opt-in and disabled on all channels", localPosition.timestamp);
+}
+
+// Position broadcasts are opt-in per channel in 2.8, but our own position still plays to the
+// connected phone/UI at full precision, like telemetry does. This copy never touches the mesh.
+// Returns true only when a packet was actually handed to the phone queue, so the caller can
+// hold off the cadence stamp (and retry soon) after a guard or allocation failure.
+bool PositionModule::sendOurPositionToPhone()
+{
+    if (!config.position.fixed_position && !nodeDB->hasLocalPositionSinceBoot())
+        return false; // Same stale-restored-position guard as sendOurPosition()
+
+    meshtastic_MeshPacket *p = allocPositionPacket(32);
+    if (p == nullptr)
+        return false;
+
+    p->to = NODENUM_BROADCAST;
+    p->decoded.want_response = false;
+    p->priority = meshtastic_MeshPacket_Priority_BACKGROUND;
+    service->sendToPhone(p);
+    return true;
 }
 
 void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t channel)
@@ -396,7 +417,7 @@ void PositionModule::sendOurPosition(NodeNum dest, bool wantReplies, uint8_t cha
     // Set the class precision value for this particular packet.
     precision = getPositionPrecisionForChannel(channel);
 
-    meshtastic_MeshPacket *p = allocPositionPacket();
+    meshtastic_MeshPacket *p = allocPositionPacket(precision);
     if (p == nullptr) {
         LOG_DEBUG("allocPositionPacket returned a nullptr");
         return;
@@ -465,6 +486,14 @@ bool PositionModule::positionWithinPrecisionCell(int32_t aLat, int32_t aLon, int
            truncateCoordinate(aLon, precision) == truncateCoordinate(bLon, precision);
 }
 
+bool PositionModule::shouldSendPositionToPhone(bool hasValidPosition, bool phoneQueueEmpty, bool everSentToPhone, uint32_t nowMs,
+                                               uint32_t lastSentMs, uint32_t intervalMs)
+{
+    if (!hasValidPosition || !phoneQueueEmpty)
+        return false;
+    return !everSentToPhone || (nowMs - lastSentMs) >= intervalMs;
+}
+
 uint32_t PositionModule::effectiveBroadcastIntervalMs(uint32_t configuredIntervalMs, bool stationary, uint32_t stationaryFloorMs)
 {
     if (stationary && stationaryFloorMs > configuredIntervalMs)
@@ -485,8 +514,20 @@ int32_t PositionModule::runOnce()
     if (node == nullptr)
         return RUNONCE_INTERVAL;
 
-    // We limit our GPS broadcasts to a max rate
     uint32_t now = millis();
+
+    // Local-only delivery, so it runs regardless of mesh opt-in state or channel utilization.
+    // Only send while the queue is empty (phone assumed connected), like telemetry. The cadence
+    // stamp only advances when a packet was actually queued, so a guard or allocation failure
+    // retries on the next tick instead of waiting out a full interval.
+    if (shouldSendPositionToPhone(nodeDB->hasValidPosition(node), service->isToPhoneQueueEmpty(), hasSentPositionToPhone, now,
+                                  lastPhoneSendMs, sendToPhoneIntervalMs) &&
+        sendOurPositionToPhone()) {
+        hasSentPositionToPhone = true;
+        lastPhoneSendMs = now;
+    }
+
+    // We limit our GPS broadcasts to a max rate
     uint32_t intervalMs = Default::getConfiguredOrDefaultMsScaled(
         config.position.position_broadcast_secs, default_broadcast_interval_secs, numOnlineNodes, TrafficType::POSITION);
     uint32_t msSinceLastSend = now - lastGpsSend;

--- a/src/modules/PositionModule.h
+++ b/src/modules/PositionModule.h
@@ -45,6 +45,12 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     // Effective min interval: stationary positions are held to stationaryFloorMs (when that is the
     // longer of the two); otherwise the normal configured interval.
     static uint32_t effectiveBroadcastIntervalMs(uint32_t configuredIntervalMs, bool stationary, uint32_t stationaryFloorMs);
+    // Pure local-play policy: stream our own position to the phone/UI when we have a valid
+    // position, the phone queue is idle, and the cadence has elapsed. everSentToPhone (rather
+    // than a lastSentMs sentinel) marks the never-sent state, so a send stamped at millis()==0
+    // still honors the cadence.
+    static bool shouldSendPositionToPhone(bool hasValidPosition, bool phoneQueueEmpty, bool everSentToPhone, uint32_t nowMs,
+                                          uint32_t lastSentMs, uint32_t intervalMs);
 
   protected:
     /** Called to handle a particular incoming message
@@ -63,7 +69,14 @@ class PositionModule : public ProtobufModule<meshtastic_Position>, private concu
     virtual int32_t runOnce() override;
 
   private:
-    meshtastic_MeshPacket *allocPositionPacket();
+    meshtastic_MeshPacket *allocPositionPacket(uint32_t atPrecision);
+    // Streams our own position to the connected phone/UI at full precision without touching the
+    // mesh. Keeps the local view alive now that mesh position sharing is opt-in. Returns true
+    // only when a packet was handed to the phone queue.
+    bool sendOurPositionToPhone();
+    bool hasSentPositionToPhone = false;
+    uint32_t lastPhoneSendMs = 0;
+    static constexpr uint32_t sendToPhoneIntervalMs = 60 * 1000; // Matches telemetry's local cadence
     struct SmartPosition getDistanceTraveledSinceLastSend(meshtastic_PositionLite currentPosition);
     // True when our position is unchanged since the last broadcast: it truncates to the same
     // precision grid cell, so re-sending would be a duplicate that traffic management dedups

--- a/src/modules/RoutingModule.cpp
+++ b/src/modules/RoutingModule.cpp
@@ -64,19 +64,20 @@ void RoutingModule::sendAckNak(meshtastic_Routing_Error err, NodeNum to, PacketI
 uint8_t RoutingModule::getHopLimitForResponse(const meshtastic_MeshPacket &mp)
 {
     const int8_t hopsUsed = getHopsAway(mp);
+    const uint8_t responseHopLimit = Default::getConfiguredOrDefaultHopLimit(config.lora.hop_limit);
     if (hopsUsed >= 0) {
-        if (hopsUsed > (int32_t)(config.lora.hop_limit)) {
-// In event mode, we never want to send packets with more than our default 3 hops.
-#if !(EVENTMODE)             // This falls through to the default.
+        if (hopsUsed > static_cast<int32_t>(responseHopLimit)) {
+// In event mode, never exceed the configured event hop limit.
+#if !USERPREFS_EVENT_MODE    // This falls through to the default.
             return hopsUsed; // If the request used more hops than the limit, use the same amount of hops
 #endif
         } else if (mp.hop_start == 0) {
             return 0; // The requesting node wanted 0 hops, so the response also uses a direct/local path.
-        } else if ((uint8_t)(hopsUsed + 2) < config.lora.hop_limit) {
+        } else if (static_cast<uint8_t>(hopsUsed + 2) < responseHopLimit) {
             return hopsUsed + 2; // Use only the amount of hops needed with some margin as the way back may be different
         }
     }
-    return Default::getConfiguredOrDefaultHopLimit(config.lora.hop_limit); // Use the default hop limit
+    return responseHopLimit;
 }
 
 meshtastic_MeshPacket *RoutingModule::allocAckNak(meshtastic_Routing_Error err, NodeNum to, PacketId idFrom, ChannelIndex chIndex,

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -259,6 +259,7 @@ meshtastic_MeshPacket *StoreForwardModule::preparePayload(NodeNum dest, uint32_t
                 p->rx_time = this->packetHistory[i].time;
                 p->decoded.emoji = (uint32_t)this->packetHistory[i].emoji;
                 p->rx_rssi = this->packetHistory[i].rx_rssi;
+                p->has_rx_rssi = true; // rx_rssi has explicit presence; the stored value was a genuine measurement
                 p->rx_snr = this->packetHistory[i].rx_snr;
                 p->hop_start = this->packetHistory[i].hop_start;
                 p->hop_limit = this->packetHistory[i].hop_limit;

--- a/src/modules/StoreForwardModule.cpp
+++ b/src/modules/StoreForwardModule.cpp
@@ -193,6 +193,9 @@ void StoreForwardModule::historyAdd(const meshtastic_MeshPacket &mp)
     }
 
     this->packetHistory[this->packetHistoryTotalCount].time = getTime();
+    // getTime() silently falls back to a boot-relative count with no RTC source at all; record
+    // whether it was actually trustworthy so replay doesn't have to guess from current quality.
+    this->packetHistory[this->packetHistoryTotalCount].has_rx_time = (getRTCQuality() >= RTCQualityFromNet);
     this->packetHistory[this->packetHistoryTotalCount].to = mp.to;
     this->packetHistory[this->packetHistoryTotalCount].channel = mp.channel;
     this->packetHistory[this->packetHistoryTotalCount].from = getFrom(&mp);
@@ -201,6 +204,7 @@ void StoreForwardModule::historyAdd(const meshtastic_MeshPacket &mp)
     this->packetHistory[this->packetHistoryTotalCount].emoji = (bool)p.emoji;
     this->packetHistory[this->packetHistoryTotalCount].payload_size = p.payload.size;
     this->packetHistory[this->packetHistoryTotalCount].rx_rssi = mp.rx_rssi;
+    this->packetHistory[this->packetHistoryTotalCount].has_rx_rssi = mp.has_rx_rssi;
     this->packetHistory[this->packetHistoryTotalCount].rx_snr = mp.rx_snr;
     this->packetHistory[this->packetHistoryTotalCount].hop_start = mp.hop_start;
     this->packetHistory[this->packetHistoryTotalCount].hop_limit = mp.hop_limit;
@@ -257,9 +261,10 @@ meshtastic_MeshPacket *StoreForwardModule::preparePayload(NodeNum dest, uint32_t
                 p->channel = this->packetHistory[i].channel;
                 p->decoded.reply_id = this->packetHistory[i].reply_id;
                 p->rx_time = this->packetHistory[i].time;
+                p->has_rx_time = this->packetHistory[i].has_rx_time; // presence captured at store time, not replay time
                 p->decoded.emoji = (uint32_t)this->packetHistory[i].emoji;
                 p->rx_rssi = this->packetHistory[i].rx_rssi;
-                p->has_rx_rssi = true; // rx_rssi has explicit presence; the stored value was a genuine measurement
+                p->has_rx_rssi = this->packetHistory[i].has_rx_rssi; // presence captured at store time, not replay time
                 p->rx_snr = this->packetHistory[i].rx_snr;
                 p->hop_start = this->packetHistory[i].hop_start;
                 p->hop_limit = this->packetHistory[i].hop_limit;

--- a/src/modules/StoreForwardModule.h
+++ b/src/modules/StoreForwardModule.h
@@ -12,6 +12,7 @@
 
 struct PacketHistoryStruct {
     uint32_t time;
+    bool has_rx_time; // whether `time` was a trustworthy epoch when captured, not a getTime() boot-relative fallback
     uint32_t to;
     uint32_t from;
     uint32_t id;
@@ -21,6 +22,7 @@ struct PacketHistoryStruct {
     uint8_t payload[meshtastic_Constants_DATA_PAYLOAD_LEN];
     pb_size_t payload_size;
     int32_t rx_rssi;
+    bool has_rx_rssi; // whether rx_rssi was a genuine measurement (e.g. not MQTT-relayed) when captured
     float rx_snr;
     uint8_t hop_start;
     uint8_t hop_limit;

--- a/src/modules/Telemetry/HealthTelemetry.cpp
+++ b/src/modules/Telemetry/HealthTelemetry.cpp
@@ -132,8 +132,13 @@ void HealthTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *
     }
 
     // Display "Health From: ..." on its own
+    char agoStr[16];
+    if (agoSecs == SINCE_UNKNOWN)
+        snprintf(agoStr, sizeof(agoStr), "?"); // no trustworthy arrival time to age against
+    else
+        snprintf(agoStr, sizeof(agoStr), "%us", (unsigned)agoSecs);
     char headerStr[64];
-    snprintf(headerStr, sizeof(headerStr), "Health From: %s(%ds)", lastSender, (int)agoSecs);
+    snprintf(headerStr, sizeof(headerStr), "Health From: %s(%s)", lastSender, agoStr);
     display->drawString(x, y, headerStr);
 
     char last_temp[16];

--- a/src/modules/Telemetry/PowerTelemetry.cpp
+++ b/src/modules/Telemetry/PowerTelemetry.cpp
@@ -154,8 +154,13 @@ void PowerTelemetryModule::drawFrame(OLEDDisplay *display, OLEDDisplayUiState *s
     }
 
     // Display "Pow. From: ..."
+    char agoStr[16];
+    if (agoSecs == SINCE_UNKNOWN)
+        snprintf(agoStr, sizeof(agoStr), "?"); // no trustworthy arrival time to age against
+    else
+        snprintf(agoStr, sizeof(agoStr), "%us", (unsigned)agoSecs);
     char fromStr[64];
-    snprintf(fromStr, sizeof(fromStr), "Pow. From: %s (%us)", lastSender, agoSecs);
+    snprintf(fromStr, sizeof(fromStr), "Pow. From: %s (%s)", lastSender, agoStr);
     display->drawString(x, graphics::getTextPositions(display)[line++], fromStr);
 
     // Display current and voltage based on ...power_metrics.has_[channel/voltage/current]... flags

--- a/src/modules/TraceRouteModule.cpp
+++ b/src/modules/TraceRouteModule.cpp
@@ -422,7 +422,11 @@ void TraceRouteModule::appendMyIDandSNR(meshtastic_RouteDiscovery *updated, floa
     }
 
     if (*snr_count < ROUTE_SIZE) {
-        snr_list[*snr_count] = (int8_t)(snr * 4); // Convert SNR to 1 byte
+        // Clamp before the cast: q4-scaled SNR at or below the demodulation floor can reach
+        // -128 (=-32dB), which is bit-identical to the INT8_MIN "unknown SNR" sentinel used
+        // throughout this file. Reserve -128 for the sentinel; clamp real readings to -127.
+        int32_t q4 = clamp<int32_t>(lroundf(snr * 4.0f), -127, 127);
+        snr_list[*snr_count] = (int8_t)q4;
         *snr_count += 1;
     }
     if (SNRonly)

--- a/src/serialization/MeshPacketSerializer.cpp
+++ b/src/serialization/MeshPacketSerializer.cpp
@@ -426,7 +426,9 @@ std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp,
     jsonObj["channel"] = (Json::UInt)mp->channel;
     jsonObj["type"] = msgType;
     jsonObj["sender"] = nodeDB->getNodeId();
-    if (mp->rx_rssi != 0)
+    // rx_rssi has explicit presence on the wire (unlike rx_snr): trust has_rx_rssi rather than a
+    // != 0 heuristic, since 0 dBm is a legitimate reading on some radios.
+    if (mp->has_rx_rssi)
         jsonObj["rssi"] = (int)mp->rx_rssi;
     if (mp->rx_snr != 0)
         jsonObj["snr"] = (float)mp->rx_snr;
@@ -456,7 +458,9 @@ std::string MeshPacketSerializer::JsonSerializeEncrypted(const meshtastic_MeshPa
     jsonObj["channel"] = (Json::UInt)mp->channel;
     jsonObj["want_ack"] = mp->want_ack;
 
-    if (mp->rx_rssi != 0)
+    // rx_rssi has explicit presence on the wire (unlike rx_snr): trust has_rx_rssi rather than a
+    // != 0 heuristic, since 0 dBm is a legitimate reading on some radios.
+    if (mp->has_rx_rssi)
         jsonObj["rssi"] = (int)mp->rx_rssi;
     if (mp->rx_snr != 0)
         jsonObj["snr"] = (float)mp->rx_snr;

--- a/src/serialization/MeshPacketSerializer.cpp
+++ b/src/serialization/MeshPacketSerializer.cpp
@@ -420,7 +420,8 @@ std::string MeshPacketSerializer::JsonSerialize(const meshtastic_MeshPacket *mp,
     }
 
     jsonObj["id"] = (Json::UInt)mp->id;
-    jsonObj["timestamp"] = (Json::UInt)mp->rx_time;
+    // Emit 0 rather than leak a millis() placeholder when has_rx_time is false.
+    jsonObj["timestamp"] = mp->has_rx_time ? (Json::UInt)mp->rx_time : 0;
     jsonObj["to"] = (Json::UInt)mp->to;
     jsonObj["from"] = (Json::UInt)mp->from;
     jsonObj["channel"] = (Json::UInt)mp->channel;
@@ -452,7 +453,8 @@ std::string MeshPacketSerializer::JsonSerializeEncrypted(const meshtastic_MeshPa
 
     jsonObj["id"] = (Json::UInt)mp->id;
     jsonObj["time_ms"] = (double)millis();
-    jsonObj["timestamp"] = (Json::UInt)mp->rx_time;
+    // Emit 0 rather than leak a millis() placeholder when has_rx_time is false.
+    jsonObj["timestamp"] = mp->has_rx_time ? (Json::UInt)mp->rx_time : 0;
     jsonObj["to"] = (Json::UInt)mp->to;
     jsonObj["from"] = (Json::UInt)mp->from;
     jsonObj["channel"] = (Json::UInt)mp->channel;

--- a/test/support/AdminModuleTestShim.h
+++ b/test/support/AdminModuleTestShim.h
@@ -29,12 +29,14 @@ class AdminModuleTestShim : public AdminModule
     {
         hasOpenEditTransaction = true;
         editTransactionActivityMs = millis();
+        setIntervalFromNow(EDIT_TRANSACTION_IDLE_MS);
         deferredShouldReboot = false;
         deferredRadioAffected = false;
     }
     int savedSegments() const { return lastSaveWhatForTest; }
 
     bool editTransactionOpen() const { return hasOpenEditTransaction; }
+    unsigned long editTransactionTimerInterval() const { return editTransactionTimerIntervalForTest(); }
     // Backdate past the idle window so a test sees an abandoned transaction without waiting it out.
     void ageEditTransaction() { editTransactionActivityMs = millis() - EDIT_TRANSACTION_IDLE_MS - 1; }
     int32_t runTransactionTimer() { return runOnce(); }

--- a/test/support/AdminModuleTestShim.h
+++ b/test/support/AdminModuleTestShim.h
@@ -37,6 +37,7 @@ class AdminModuleTestShim : public AdminModule
     bool editTransactionOpen() const { return hasOpenEditTransaction; }
     // Backdate past the idle window so a test sees an abandoned transaction without waiting it out.
     void ageEditTransaction() { editTransactionActivityMs = millis() - EDIT_TRANSACTION_IDLE_MS - 1; }
+    int32_t runTransactionTimer() { return runOnce(); }
 
     // Setters may allocate an error reply from packetPool; drain it each iteration or the pool leaks.
     void drainReply()

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -3139,6 +3139,19 @@ static void test_abandonedTransaction_timerExpiresWithoutAdminTraffic()
     TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
 }
 
+static void test_editTransactionTimer_isDormantUntilTransactionBegins()
+{
+    TEST_ASSERT_EQUAL_UINT32(INT32_MAX, testAdmin->editTransactionTimerInterval());
+    TEST_ASSERT_EQUAL_INT32(INT32_MAX, testAdmin->runTransactionTimer());
+
+    sendBeginEdit();
+    TEST_ASSERT_EQUAL_UINT32(60 * 1000, testAdmin->editTransactionTimerInterval());
+
+    sendCommitEdit();
+    TEST_ASSERT_EQUAL_UINT32(INT32_MAX, testAdmin->editTransactionTimerInterval());
+    TEST_ASSERT_EQUAL_INT32(INT32_MAX, testAdmin->runTransactionTimer());
+}
+
 // Expiry must consume-and-clear the accumulated decisions, not just read them. A begin would reset
 // them anyway, so the leak only shows through the one path that consumes them without a begin: a
 // stray commit. Left uncleared, it inherits the abandoned LoRa transaction's answer and reloads.
@@ -3393,6 +3406,7 @@ void setup()
     RUN_TEST(test_abandonedTransaction_loraSet_stillReloadsRadioOnExpiry);
     RUN_TEST(test_abandonedTransaction_rebootingFieldRebootsOnExpiry);
     RUN_TEST(test_abandonedTransaction_timerExpiresWithoutAdminTraffic);
+    RUN_TEST(test_editTransactionTimer_isDormantUntilTransactionBegins);
     RUN_TEST(test_abandonedTransaction_flagsDoNotLeakIntoAStrayCommit);
 
     exit(UNITY_END());

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -1860,6 +1860,33 @@ static void test_setChannel_primaryNameChange_triggersRadioReload()
     TEST_ASSERT_EQUAL_INT(1, counter.count);
 }
 
+static void test_setChannel_primaryNameChangeWithExplicitFrequency_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    config.lora.override_frequency = 915.0f;
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "FieldTest", DEFAULT_KEY, 1));
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_primaryNameChangeWithPersistedHashSlot_reloadsRadio()
+{
+    usePresetLongFast();
+    config.lora.channel_num = 1;
+    RadioInterface::uses_default_frequency_slot = true;
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "FieldTest", DEFAULT_KEY, 1));
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
 static void test_setChannel_noop_doesNotReloadRadio()
 {
     usePresetLongFast();
@@ -2087,6 +2114,42 @@ static void test_setConfigLora_noop_doesNotReloadRadio()
     sendSetConfig(c);
 
     TEST_ASSERT_FALSE(mockMeshService->lastRadioAffected);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigLora_policyOnlyChange_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.hop_limit = config.lora.hop_limit + 1;
+    c.payload_variant.lora.ignore_mqtt = !config.lora.ignore_mqtt;
+    c.payload_variant.lora.config_ok_to_mqtt = !config.lora.config_ok_to_mqtt;
+    c.payload_variant.lora.override_duty_cycle = !config.lora.override_duty_cycle;
+    c.payload_variant.lora.ignore_incoming_count = 1;
+    c.payload_variant.lora.ignore_incoming[0] = 0x12345678;
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setConfigLora_liveHardwareFields_dontReloadRadio()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.tx_enabled = !config.lora.tx_enabled;
+    c.payload_variant.lora.pa_fan_disabled = !config.lora.pa_fan_disabled;
+    sendSetConfig(c);
+
     TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
@@ -2585,6 +2648,145 @@ static void sendSetModuleConfig(const meshtastic_ModuleConfig &mc)
     sendAdmin(m);
 }
 
+static void test_setModuleConfigMqtt_redactedSecretNoop_doesNotRebootOrDisableBluetooth()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    strncpy(moduleConfig.mqtt.password, "actual-password", sizeof(moduleConfig.mqtt.password) - 1);
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    strncpy(mc.payload_variant.mqtt.password, "sekrit", sizeof(mc.payload_variant.mqtt.password) - 1);
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_STRING("actual-password", moduleConfig.mqtt.password);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigSerial_noop_doesNotRebootOrDisableBluetooth()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigMqtt_realChangeRebootsAndDisablesBluetooth()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    mc.payload_variant.mqtt.encryption_enabled = true;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setModuleConfigSerial_realChangeRebootsAndDisablesBluetooth()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+    mc.payload_variant.serial.echo = true;
+    rebootAtMsec = 0;
+
+    sendSetModuleConfig(mc);
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_transaction_mqttNoop_keepsBluetoothUntilCommit()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    strncpy(moduleConfig.mqtt.password, "actual-password", sizeof(moduleConfig.mqtt.password) - 1);
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    strncpy(mc.payload_variant.mqtt.password, "sekrit", sizeof(mc.payload_variant.mqtt.password) - 1);
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_mqttRealChange_disablesBluetoothAtCommit()
+{
+    moduleConfig.has_mqtt = true;
+    moduleConfig.mqtt = meshtastic_ModuleConfig_MQTTConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_mqtt_tag;
+    mc.payload_variant.mqtt = moduleConfig.mqtt;
+    mc.payload_variant.mqtt.encryption_enabled = true;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_transaction_serialNoop_keepsBluetoothUntilCommit()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_serialRealChange_disablesBluetoothAtCommit()
+{
+    moduleConfig.has_serial = true;
+    moduleConfig.serial = meshtastic_ModuleConfig_SerialConfig_init_zero;
+    meshtastic_ModuleConfig mc = meshtastic_ModuleConfig_init_zero;
+    mc.which_payload_variant = meshtastic_ModuleConfig_serial_tag;
+    mc.payload_variant.serial = moduleConfig.serial;
+    mc.payload_variant.serial.echo = true;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    sendSetModuleConfig(mc);
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
 // The headline guard: favoriting a node inside a transaction must not reconfigure the radio when
 // the transaction commits. Outside a transaction the segment bitmask makes this unreachable; here
 // it is reachable, and only radioAffected=false keeps it shut.
@@ -2895,9 +3097,9 @@ static void test_abandonedTransaction_loraSet_stillReloadsRadioOnExpiry()
     TEST_ASSERT_EQUAL_INT(1, counter.count);
 }
 
-// Reboot is the one axis abandonment deliberately drops: the settings are already live in RAM and
-// the client that asked for the restart is, by definition, gone.
-static void test_abandonedTransaction_rebootingFieldDoesNotRebootOnExpiry()
+// Boot-only settings are not actually live in RAM. Expiry must finish the same reboot the commit
+// would have requested, or it persists a value that cannot take effect until some unrelated reboot.
+static void test_abandonedTransaction_rebootingFieldRebootsOnExpiry()
 {
     config.position.rx_gpio = 0; // a genuinely boot-only field, so the drop is a real drop
     rebootAtMsec = 0;
@@ -2913,7 +3115,28 @@ static void test_abandonedTransaction_rebootingFieldDoesNotRebootOnExpiry()
     sendGetDeviceMetadata();
 
     TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
-    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+}
+
+static void test_abandonedTransaction_timerExpiresWithoutAdminTraffic()
+{
+    config.position.rx_gpio = 0;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+
+    testAdmin->ageEditTransaction();
+    testAdmin->runTransactionTimer();
+
+    TEST_ASSERT_FALSE(testAdmin->editTransactionOpen());
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
 }
 
 // Expiry must consume-and-clear the accumulated decisions, not just read them. A begin would reset
@@ -3093,6 +3316,8 @@ void setup()
     RUN_TEST(test_removeIgnoredNode_skipsRadioReload);
     RUN_TEST(test_toggleMutedNode_skipsRadioReload_butPersists);
     RUN_TEST(test_setChannel_primaryNameChange_triggersRadioReload);
+    RUN_TEST(test_setChannel_primaryNameChangeWithExplicitFrequency_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_primaryNameChangeWithPersistedHashSlot_reloadsRadio);
     RUN_TEST(test_setChannel_noop_doesNotReloadRadio);
     RUN_TEST(test_setChannel_mqttFlagChange_doesNotReloadRadio);
     RUN_TEST(test_setChannel_pskChange_doesNotReloadRadio);
@@ -3107,6 +3332,8 @@ void setup()
     RUN_TEST(test_removeFixedPosition_skipsRadioReload);
     RUN_TEST(test_setConfigLora_realChange_triggersRadioReload);
     RUN_TEST(test_setConfigLora_noop_doesNotReloadRadio);
+    RUN_TEST(test_setConfigLora_policyOnlyChange_doesNotReloadRadio);
+    RUN_TEST(test_setConfigLora_liveHardwareFields_dontReloadRadio);
     RUN_TEST(test_reloadConfig_defaultRadioAffected_stillReloads);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_skipsReload);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_isEquivalentToSaveToDisk);
@@ -3143,6 +3370,14 @@ void setup()
     // Edit-transaction deferral (the path phone apps use)
     RUN_TEST(test_transaction_favoriteNode_doesNotReloadRadioAtCommit);
     RUN_TEST(test_transaction_toggleMutedNode_doesNotReloadRadioAtCommit);
+    RUN_TEST(test_setModuleConfigMqtt_redactedSecretNoop_doesNotRebootOrDisableBluetooth);
+    RUN_TEST(test_setModuleConfigSerial_noop_doesNotRebootOrDisableBluetooth);
+    RUN_TEST(test_setModuleConfigMqtt_realChangeRebootsAndDisablesBluetooth);
+    RUN_TEST(test_setModuleConfigSerial_realChangeRebootsAndDisablesBluetooth);
+    RUN_TEST(test_transaction_mqttNoop_keepsBluetoothUntilCommit);
+    RUN_TEST(test_transaction_mqttRealChange_disablesBluetoothAtCommit);
+    RUN_TEST(test_transaction_serialNoop_keepsBluetoothUntilCommit);
+    RUN_TEST(test_transaction_serialRealChange_disablesBluetoothAtCommit);
     RUN_TEST(test_transaction_moduleConfigSet_doesNotReloadRadioAtCommit);
     RUN_TEST(test_transaction_positionGpsOffNestedSave_doesNotReloadRadioAtCommit);
     RUN_TEST(test_transaction_loraSet_stillReloadsRadioAtCommit);
@@ -3156,7 +3391,8 @@ void setup()
     RUN_TEST(test_commitWithoutBegin_persistsButDoesNotReloadOrReboot);
     RUN_TEST(test_abandonedTransaction_liveOnlyBatch_expiresWithoutReloadOrReboot);
     RUN_TEST(test_abandonedTransaction_loraSet_stillReloadsRadioOnExpiry);
-    RUN_TEST(test_abandonedTransaction_rebootingFieldDoesNotRebootOnExpiry);
+    RUN_TEST(test_abandonedTransaction_rebootingFieldRebootsOnExpiry);
+    RUN_TEST(test_abandonedTransaction_timerExpiresWithoutAdminTraffic);
     RUN_TEST(test_abandonedTransaction_flagsDoNotLeakIntoAStrayCommit);
 
     exit(UNITY_END());

--- a/test/test_admin_radio/test_main.cpp
+++ b/test/test_admin_radio/test_main.cpp
@@ -39,6 +39,7 @@ extern uint32_t hash(const char *str);
 
 // Set by AdminModule::reboot(); the reboot-gating tests assert on it (0 == no reboot scheduled).
 extern uint32_t rebootAtMsec;
+extern uint32_t disableBluetoothCallCountForTest;
 
 // Every client notification the AdminModule emits flows through sendClientNotification();
 // capture each formatted message so the warning/coalescing tests can assert on the exact
@@ -58,9 +59,11 @@ class MockMeshService : public MeshService
     // Counts entries into reloadConfig(). Lets a test assert a code path writes *once*, which
     // configChanged alone cannot show (a suppressed reload still persists).
     int reloadCalls = 0;
+    bool lastRadioAffected = false;
     void reloadConfig(int saveWhat, bool radioAffected) override
     {
         reloadCalls++;
+        lastRadioAffected = radioAffected;
         MeshService::reloadConfig(saveWhat, radioAffected);
     }
 };
@@ -1845,17 +1848,58 @@ static void test_toggleMutedNode_skipsRadioReload_butPersists()
     TEST_ASSERT_TRUE(nodeInfoLiteIsMuted(nodeDB->getMeshNode(TEST_NODE_NUM)));
 }
 
-// Regression guard: a real LoRa config/channel change must still reconfigure the radio -
-// the gate in reloadConfig() must not have swallowed the legitimate case.
-static void test_setChannel_stillTriggersRadioReload()
+static void test_setChannel_primaryNameChange_triggersRadioReload()
 {
     usePresetLongFast();
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
     ConfigChangedCounter counter;
     counter.observe(&service->configChanged);
 
-    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1));
+    sendSetChannel(makeChannel(0, meshtastic_Channel_Role_PRIMARY, "FieldTest", DEFAULT_KEY, 1));
 
     TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+static void test_setChannel_noop_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    const meshtastic_Channel channel = makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1);
+    sendSetChannel(channel);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendSetChannel(channel);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_mqttFlagChange_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    meshtastic_Channel channel = makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1);
+    sendSetChannel(channel);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    channel.settings.uplink_enabled = !channel.settings.uplink_enabled;
+    sendSetChannel(channel);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+}
+
+static void test_setChannel_pskChange_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    meshtastic_Channel channel = makeChannel(0, meshtastic_Channel_Role_PRIMARY, "LongFast", DEFAULT_KEY, 1);
+    sendSetChannel(channel);
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    channel.settings.psk.size = sizeof(CUSTOM_KEY);
+    memcpy(channel.settings.psk.bytes, CUSTOM_KEY, sizeof(CUSTOM_KEY));
+    sendSetChannel(channel);
+
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
 // -----------------------------------------------------------------------
@@ -2015,10 +2059,7 @@ static void test_removeFixedPosition_skipsRadioReload()
     TEST_ASSERT_FALSE(config.position.fixed_position);
 }
 
-// Regression guard: a set_config carrying the lora sub-message is the one case that must
-// still fire configChanged. Sending back the current valid preset leaves the region
-// unchanged, so exactly one reload occurs.
-static void test_setConfigLora_stillTriggersRadioReload()
+static void test_setConfigLora_realChange_triggersRadioReload()
 {
     usePresetLongFast();
     ConfigChangedCounter counter;
@@ -2027,9 +2068,26 @@ static void test_setConfigLora_stillTriggersRadioReload()
     meshtastic_Config c = meshtastic_Config_init_zero;
     c.which_payload_variant = meshtastic_Config_lora_tag;
     c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
     sendSetConfig(c);
 
     TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+static void test_setConfigLora_noop_doesNotReloadRadio()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
+    sendSetConfig(c);
+
+    TEST_ASSERT_FALSE(mockMeshService->lastRadioAffected);
+    TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
 // Default-preservation guard: reloadConfig() callers that pass only saveWhat (MenuHandler,
@@ -2340,6 +2398,20 @@ static void test_setConfigNetwork_realChange_schedulesReboot()
     sendSetConfig(c);
 
     TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
+static void test_setConfigNetwork_redactedSecretNoop_doesNotReboot()
+{
+    strncpy(config.network.wifi_psk, "existing-test-secret", sizeof(config.network.wifi_psk) - 1);
+    rebootAtMsec = 0;
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_network_tag;
+    c.payload_variant.network = config.network;
+    strncpy(c.payload_variant.network.wifi_psk, "sekrit", sizeof(c.payload_variant.network.wifi_psk) - 1);
+    sendSetConfig(c);
+
+    TEST_ASSERT_EQUAL_UINT32(0, rebootAtMsec);
+    TEST_ASSERT_EQUAL_STRING("existing-test-secret", config.network.wifi_psk);
 }
 
 static void test_setConfigBluetooth_noopSet_doesNotReboot()
@@ -2667,6 +2739,68 @@ static void test_transaction_liveOnlyBatch_neitherRebootsNorReloads()
     TEST_ASSERT_EQUAL_INT(0, counter.count);
 }
 
+static void test_transaction_liveOnlyCommit_doesNotDisableBluetooth()
+{
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.position_broadcast_secs = config.position.position_broadcast_secs + 60;
+    sendSetConfig(c);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(0, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_rebootingCommit_disablesBluetooth()
+{
+    config.position.rx_gpio = 0;
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_UINT32(1, disableBluetoothCallCountForTest);
+}
+
+static void test_transaction_duplicateBegin_preservesRadioReload()
+{
+    usePresetLongFast();
+    ConfigChangedCounter counter;
+    counter.observe(&service->configChanged);
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_lora_tag;
+    c.payload_variant.lora = config.lora;
+    c.payload_variant.lora.modem_preset = meshtastic_Config_LoRaConfig_ModemPreset_MEDIUM_FAST;
+    sendSetConfig(c);
+    sendBeginEdit();
+    sendCommitEdit();
+
+    TEST_ASSERT_EQUAL_INT(1, counter.count);
+}
+
+static void test_transaction_duplicateBegin_preservesReboot()
+{
+    config.position.rx_gpio = 0;
+    rebootAtMsec = 0;
+
+    sendBeginEdit();
+    meshtastic_Config c = meshtastic_Config_init_zero;
+    c.which_payload_variant = meshtastic_Config_position_tag;
+    c.payload_variant.position = config.position;
+    c.payload_variant.position.rx_gpio = 17;
+    sendSetConfig(c);
+    sendBeginEdit();
+    sendCommitEdit();
+
+    TEST_ASSERT_NOT_EQUAL(0, rebootAtMsec);
+}
+
 // The accumulated decisions are per-transaction: a LoRa transaction must not leave the next,
 // node-DB-only transaction reconfiguring the radio.
 static void test_transaction_flagsDoNotLeakIntoTheNextTransaction()
@@ -2818,6 +2952,7 @@ void setUp(void)
     mockMeshService = new MockMeshService();
     service = mockMeshService;
     testAdmin = new AdminModuleTestShim();
+    disableBluetoothCallCountForTest = 0;
     capturedWarnings.clear();
     // Committing an edit transaction triggers a full saveToDisk(), which dereferences nodeDB.
     // Create it once (kept reachable via the global, so no leak) for the warning tests; the
@@ -2957,7 +3092,10 @@ void setup()
     RUN_TEST(test_setIgnoredNode_skipsRadioReload_butPersists);
     RUN_TEST(test_removeIgnoredNode_skipsRadioReload);
     RUN_TEST(test_toggleMutedNode_skipsRadioReload_butPersists);
-    RUN_TEST(test_setChannel_stillTriggersRadioReload);
+    RUN_TEST(test_setChannel_primaryNameChange_triggersRadioReload);
+    RUN_TEST(test_setChannel_noop_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_mqttFlagChange_doesNotReloadRadio);
+    RUN_TEST(test_setChannel_pskChange_doesNotReloadRadio);
     RUN_TEST(test_setConfigDevice_skipsRadioReload);
     RUN_TEST(test_setConfigPosition_skipsRadioReload);
     RUN_TEST(test_setConfigPosition_gpsOffNestedSave_skipsRadioReload);
@@ -2967,7 +3105,8 @@ void setup()
     RUN_TEST(test_setConfigBluetooth_skipsRadioReload);
     RUN_TEST(test_setConfigSecurity_skipsRadioReload);
     RUN_TEST(test_removeFixedPosition_skipsRadioReload);
-    RUN_TEST(test_setConfigLora_stillTriggersRadioReload);
+    RUN_TEST(test_setConfigLora_realChange_triggersRadioReload);
+    RUN_TEST(test_setConfigLora_noop_doesNotReloadRadio);
     RUN_TEST(test_reloadConfig_defaultRadioAffected_stillReloads);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_skipsReload);
     RUN_TEST(test_reloadConfig_radioAffectedFalse_isEquivalentToSaveToDisk);
@@ -2990,6 +3129,7 @@ void setup()
     RUN_TEST(test_setConfigPosition_gpioChange_schedulesReboot);
     RUN_TEST(test_setConfigNetwork_noopSet_doesNotReboot);
     RUN_TEST(test_setConfigNetwork_realChange_schedulesReboot);
+    RUN_TEST(test_setConfigNetwork_redactedSecretNoop_doesNotReboot);
     RUN_TEST(test_setConfigBluetooth_noopSet_doesNotReboot);
     RUN_TEST(test_setConfigBluetooth_realChange_schedulesReboot);
     RUN_TEST(test_setConfigPosition_liveFieldChange_doesNotReboot);
@@ -3008,6 +3148,10 @@ void setup()
     RUN_TEST(test_transaction_loraSet_stillReloadsRadioAtCommit);
     RUN_TEST(test_transaction_gpioSet_reboots_butDoesNotReloadRadio);
     RUN_TEST(test_transaction_liveOnlyBatch_neitherRebootsNorReloads);
+    RUN_TEST(test_transaction_liveOnlyCommit_doesNotDisableBluetooth);
+    RUN_TEST(test_transaction_rebootingCommit_disablesBluetooth);
+    RUN_TEST(test_transaction_duplicateBegin_preservesRadioReload);
+    RUN_TEST(test_transaction_duplicateBegin_preservesReboot);
     RUN_TEST(test_transaction_flagsDoNotLeakIntoTheNextTransaction);
     RUN_TEST(test_commitWithoutBegin_persistsButDoesNotReloadOrReboot);
     RUN_TEST(test_abandonedTransaction_liveOnlyBatch_expiresWithoutReloadOrReboot);

--- a/test/test_default/test_main.cpp
+++ b/test/test_default/test_main.cpp
@@ -3,6 +3,8 @@
 #include "MeshRadio.h"
 #include "TestUtil.h"
 #include "meshUtils.h"
+#include "modules/RoutingModule.h"
+#include <algorithm>
 #include <unity.h>
 
 // Helper to compute expected ms using same logic as Default::congestionScalingCoefficient
@@ -181,6 +183,32 @@ void test_scaled_overflow_saturates()
     TEST_ASSERT_EQUAL_UINT32(static_cast<uint32_t>(INT32_MAX), res);
 }
 
+void test_configured_or_default_hop_limit()
+{
+    config.lora.hop_limit = HOP_MAX;
+    const uint8_t result = Default::getConfiguredOrDefaultHopLimit(config.lora.hop_limit);
+
+#if USERPREFS_EVENT_MODE
+    TEST_ASSERT_EQUAL_UINT8(Default::eventModeHopLimit, result);
+    TEST_ASSERT_EQUAL_UINT8(Default::eventModeHopLimit, Default::getConfiguredOrDefaultHopLimit(Default::eventModeHopLimit));
+#else
+    TEST_ASSERT_EQUAL_UINT8(HOP_MAX, result);
+#endif
+}
+
+#if USERPREFS_EVENT_MODE
+void test_event_mode_caps_optimized_response()
+{
+    config.lora.hop_limit = HOP_MAX;
+    meshtastic_MeshPacket request = meshtastic_MeshPacket_init_zero;
+    request.hop_start = HOP_MAX;
+    request.hop_limit = HOP_MAX - 4;
+
+    RoutingModule module;
+    TEST_ASSERT_EQUAL_UINT8(std::min<uint8_t>(6, Default::eventModeHopLimit), module.getHopLimitForResponse(request));
+}
+#endif
+
 void setup()
 {
     // Small delay to match other test mains
@@ -201,6 +229,10 @@ void setup()
     RUN_TEST(test_ms_default_clamps);
     RUN_TEST(test_ms_result_is_int32_safe);
     RUN_TEST(test_scaled_overflow_saturates);
+    RUN_TEST(test_configured_or_default_hop_limit);
+#if USERPREFS_EVENT_MODE
+    RUN_TEST(test_event_mode_caps_optimized_response);
+#endif
     exit(UNITY_END());
 }
 

--- a/test/test_fuzz_packets/test_main.cpp
+++ b/test/test_fuzz_packets/test_main.cpp
@@ -616,6 +616,7 @@ void test_E7_nodedb_update_fuzz(void)
             mp.id = rngNext();
             mp.rx_snr = (float)((int)rngRange(60) - 30);
             mp.rx_rssi = (int32_t)rngRange(256) - 128;
+            mp.has_rx_rssi = (rngRange(2) != 0); // exercise both the presence and absence paths
             mp.hop_start = (uint8_t)rngRange(8);
             mp.hop_limit = (uint8_t)rngRange(8);
             mp.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
@@ -666,6 +667,7 @@ static void fuzzRxHeader(meshtastic_MeshPacket &mp, meshtastic_PortNum portnum)
     mp.channel = (uint8_t)rngRange(channels.getNumChannels());
     mp.rx_snr = (float)((int)rngRange(40) - 20);
     mp.rx_rssi = -(int)rngRange(130);
+    mp.has_rx_rssi = (rngRange(2) != 0); // exercise both the presence and absence paths
     mp.hop_start = (uint8_t)rngRange(8); // 0..7, wire-bounded
     mp.hop_limit = (uint8_t)rngRange(8);
     mp.want_ack = (rngRange(2) == 0);

--- a/test/test_meshpacket_serializer/ports/test_timestamp.cpp
+++ b/test/test_meshpacket_serializer/ports/test_timestamp.cpp
@@ -1,0 +1,37 @@
+#include "../test_helpers.h"
+
+void test_timestamp_present_when_has_rx_time()
+{
+    const char *test_text = "hi";
+    meshtastic_MeshPacket packet =
+        create_test_packet(meshtastic_PortNum_TEXT_MESSAGE_APP, reinterpret_cast<const uint8_t *>(test_text), strlen(test_text));
+
+    std::string json = MeshPacketSerializer::JsonSerialize(&packet, false);
+    Json::Value root = parse_json(json);
+    TEST_ASSERT_TRUE(root.isMember("timestamp"));
+    TEST_ASSERT_EQUAL_UINT32(1609459200u, root["timestamp"].asUInt());
+}
+
+void test_timestamp_zeroed_when_rx_time_absent()
+{
+    const char *test_text = "hi";
+    meshtastic_MeshPacket packet = create_test_packet_no_rx_time(meshtastic_PortNum_TEXT_MESSAGE_APP,
+                                                                 reinterpret_cast<const uint8_t *>(test_text), strlen(test_text));
+
+    std::string json = MeshPacketSerializer::JsonSerialize(&packet, false);
+    Json::Value root = parse_json(json);
+    TEST_ASSERT_TRUE(root.isMember("timestamp"));
+    TEST_ASSERT_EQUAL_UINT32(0u, root["timestamp"].asUInt()); // must not leak the millis() placeholder
+}
+
+void test_encrypted_timestamp_zeroed_when_rx_time_absent()
+{
+    const char *test_text = "hi";
+    meshtastic_MeshPacket packet = create_test_packet_no_rx_time(meshtastic_PortNum_TEXT_MESSAGE_APP,
+                                                                 reinterpret_cast<const uint8_t *>(test_text), strlen(test_text));
+
+    std::string json = MeshPacketSerializer::JsonSerializeEncrypted(&packet);
+    Json::Value root = parse_json(json);
+    TEST_ASSERT_TRUE(root.isMember("timestamp"));
+    TEST_ASSERT_EQUAL_UINT32(0u, root["timestamp"].asUInt());
+}

--- a/test/test_meshpacket_serializer/test_helpers.h
+++ b/test/test_meshpacket_serializer/test_helpers.h
@@ -40,6 +40,7 @@ static meshtastic_MeshPacket create_test_packet(meshtastic_PortNum port, const u
     packet.rx_snr = 10.5f;
     packet.hop_start = 3;
     packet.rx_rssi = -85;
+    packet.has_rx_rssi = true; // rx_rssi has explicit presence; mark this synthetic reading as measured
     packet.delayed = meshtastic_MeshPacket_Delayed_NO_DELAY;
 
     // Set decoded variant

--- a/test/test_meshpacket_serializer/test_helpers.h
+++ b/test/test_meshpacket_serializer/test_helpers.h
@@ -37,6 +37,7 @@ static meshtastic_MeshPacket create_test_packet(meshtastic_PortNum port, const u
     packet.want_ack = false;
     packet.priority = meshtastic_MeshPacket_Priority_UNSET;
     packet.rx_time = 1609459200;
+    packet.has_rx_time = true; // rx_time has explicit presence; mark this synthetic reading as measured
     packet.rx_snr = 10.5f;
     packet.hop_start = 3;
     packet.rx_rssi = -85;
@@ -60,5 +61,16 @@ static meshtastic_MeshPacket create_test_packet(meshtastic_PortNum port, const u
     packet.decoded.reply_id = 0;
     packet.decoded.emoji = 0;
 
+    return packet;
+}
+
+// Same as create_test_packet(), but with rx_time absent (has_rx_time = false) and a nonzero
+// millis()-style placeholder in rx_time, to verify serializers treat it as unknown, not a reading.
+static meshtastic_MeshPacket create_test_packet_no_rx_time(meshtastic_PortNum port, const uint8_t *payload, size_t payload_size,
+                                                           int payload_variant = meshtastic_MeshPacket_decoded_tag)
+{
+    meshtastic_MeshPacket packet = create_test_packet(port, payload, payload_size, payload_variant);
+    packet.rx_time = 123456; // a plausible millis() placeholder, not a real epoch
+    packet.has_rx_time = false;
     return packet;
 }

--- a/test/test_meshpacket_serializer/test_serializer.cpp
+++ b/test/test_meshpacket_serializer/test_serializer.cpp
@@ -19,6 +19,9 @@ void test_telemetry_environment_metrics_complete_coverage();
 void test_telemetry_environment_metrics_unset_fields();
 void test_encrypted_packet_serialization();
 void test_empty_encrypted_packet();
+void test_timestamp_present_when_has_rx_time();
+void test_timestamp_zeroed_when_rx_time_absent();
+void test_encrypted_timestamp_zeroed_when_rx_time_absent();
 
 void setup()
 {
@@ -51,6 +54,11 @@ void setup()
     // Encrypted packet test
     RUN_TEST(test_encrypted_packet_serialization);
     RUN_TEST(test_empty_encrypted_packet);
+
+    // rx_time explicit-presence tests
+    RUN_TEST(test_timestamp_present_when_has_rx_time);
+    RUN_TEST(test_timestamp_zeroed_when_rx_time_absent);
+    RUN_TEST(test_encrypted_timestamp_zeroed_when_rx_time_absent);
 
     UNITY_END();
 }

--- a/test/test_nexthop_routing/test_main.cpp
+++ b/test/test_nexthop_routing/test_main.cpp
@@ -13,6 +13,7 @@
 
 #include "configuration.h"
 #include "gps/RTC.h"
+#include "mesh/Default.h"
 #include "mesh/NextHopRouter.h"
 #include "mesh/NodeDB.h"
 #include "mesh/RadioInterface.h"
@@ -89,6 +90,7 @@ class NextHopRouterTestShim : public NextHopRouter
     using NextHopRouter::noteRouteLearned;
     using NextHopRouter::noteRouteSuccess;
     using NextHopRouter::perhapsRebroadcast;
+    using NextHopRouter::relayOpaquePacket;
     using Router::shouldDecrementHopLimit; // protected in Router
 
     void resetRouteHealthForTest()
@@ -108,6 +110,8 @@ class MockRadioInterface : public RadioInterface
     ErrorCode send(meshtastic_MeshPacket *p) override
     {
         sendCount++;
+        lastHopLimit = p->hop_limit;
+        lastHopStart = p->hop_start;
         if (declineAll || p->to == NODENUM_BROADCAST_NO_LORA)
             return ERRNO_SHOULD_RELEASE;
 
@@ -124,6 +128,8 @@ class MockRadioInterface : public RadioInterface
 
     int sendCount = 0;
     bool declineAll = false;
+    uint8_t lastHopLimit = 0;
+    uint8_t lastHopStart = 0;
 };
 
 static MockNodeDB *mockNodeDB = nullptr;
@@ -498,6 +504,46 @@ void test_rebroadcast_declined_send_releases_packet(void)
     TEST_ASSERT_EQUAL_MESSAGE(1, mockIface->sendCount, "the copy must have reached the mock radio");
 }
 
+#if USERPREFS_EVENT_MODE
+void test_event_mode_hop_behavior(void)
+{
+    MockRadioInterface *mockIface = installMockIface();
+    meshtastic_MeshPacket p = makeRebroadcastCandidate(NODENUM_BROADCAST);
+    p.from = kLocalNode;
+    p.hop_start = 0;
+    p.hop_limit = HOP_MAX;
+
+    TEST_ASSERT_EQUAL(ERRNO_OK, shim->send(packetPool.allocCopy(p)));
+    TEST_ASSERT_EQUAL_UINT8(HOP_MAX, mockIface->lastHopLimit);
+    TEST_ASSERT_EQUAL_UINT8(HOP_MAX, mockIface->lastHopStart);
+
+    p = makeRebroadcastCandidate(NODENUM_BROADCAST);
+    p.hop_start = HOP_MAX;
+    p.hop_limit = HOP_MAX;
+
+    TEST_ASSERT_TRUE(shim->perhapsRebroadcast(&p));
+    TEST_ASSERT_EQUAL_UINT8(Default::eventModeRelayHopLimit, mockIface->lastHopLimit);
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(Default::eventModeRelayHopLimit + 1), mockIface->lastHopStart);
+
+    config.device.rebroadcast_mode = meshtastic_Config_DeviceConfig_RebroadcastMode_ALL;
+    p = makeRebroadcastCandidate(NODENUM_BROADCAST);
+    p.hop_start = HOP_MAX;
+    p.hop_limit = HOP_MAX;
+
+    TEST_ASSERT_TRUE(shim->relayOpaquePacket(&p));
+    TEST_ASSERT_EQUAL_UINT8(Default::eventModeRelayHopLimit, mockIface->lastHopLimit);
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(Default::eventModeRelayHopLimit + 1), mockIface->lastHopStart);
+
+    p = makeRebroadcastCandidate(NODENUM_BROADCAST);
+    p.hop_start = 0;
+    p.hop_limit = HOP_MAX;
+
+    TEST_ASSERT_TRUE(shim->relayOpaquePacket(&p));
+    TEST_ASSERT_EQUAL_UINT8(Default::eventModeRelayHopLimit, mockIface->lastHopLimit);
+    TEST_ASSERT_EQUAL_UINT8(0, mockIface->lastHopStart);
+}
+#endif
+
 // ===========================================================================
 
 void setup()
@@ -552,6 +598,9 @@ void setup()
     RUN_TEST(test_rebroadcast_normal_broadcast_is_relayed);
     RUN_TEST(test_rebroadcast_no_lora_broadcast_is_not_relayed);
     RUN_TEST(test_rebroadcast_declined_send_releases_packet);
+#if USERPREFS_EVENT_MODE
+    RUN_TEST(test_event_mode_hop_behavior);
+#endif
 
     exit(UNITY_END());
 }

--- a/test/test_position_module/test_main.cpp
+++ b/test/test_position_module/test_main.cpp
@@ -56,6 +56,56 @@ static void test_effectiveInterval_zeroFloorIsNoOp()
     TEST_ASSERT_EQUAL_UINT32(60000U, PositionModule::effectiveBroadcastIntervalMs(60000U, true, 0U));
 }
 
+// Local phone/UI play: positions are opt-in on the mesh, but our own position still streams to
+// the connected phone at a fixed cadence (mirroring telemetry's local delivery).
+
+// A never-sent state streams immediately once a valid position exists, regardless of the clock.
+static void test_sendToPhone_firstSendIsImmediate()
+{
+    TEST_ASSERT_TRUE(PositionModule::shouldSendPositionToPhone(true, true, false, 5000U, 0U, 60000U));
+    TEST_ASSERT_TRUE(PositionModule::shouldSendPositionToPhone(true, true, false, 0U, 0U, 60000U));
+}
+
+static void test_sendToPhone_holdsUntilCadenceElapses()
+{
+    TEST_ASSERT_FALSE(PositionModule::shouldSendPositionToPhone(true, true, true, 59999U, 1U, 60000U));
+}
+
+static void test_sendToPhone_sendsWhenCadenceElapses()
+{
+    TEST_ASSERT_TRUE(PositionModule::shouldSendPositionToPhone(true, true, true, 60001U, 1U, 60000U));
+}
+
+// No valid local position yet (e.g. GPS has no fix since boot): nothing to stream.
+static void test_sendToPhone_requiresValidPosition()
+{
+    TEST_ASSERT_FALSE(PositionModule::shouldSendPositionToPhone(false, true, true, 60001U, 1U, 60000U));
+}
+
+// A backed-up toPhone queue means no client is draining it; don't pile on.
+static void test_sendToPhone_requiresIdlePhoneQueue()
+{
+    TEST_ASSERT_FALSE(PositionModule::shouldSendPositionToPhone(true, false, true, 60001U, 1U, 60000U));
+}
+
+// millis() rollover: unsigned subtraction keeps the elapsed math correct across the wrap.
+static void test_sendToPhone_survivesMillisRollover()
+{
+    constexpr uint32_t lastSent = UINT32_MAX - 29999U; // exactly 30,000 ms before the wrap to 0
+    // "now" 40s after the wrap: 70,000 ms elapsed >= the 60s cadence, so it sends.
+    TEST_ASSERT_TRUE(PositionModule::shouldSendPositionToPhone(true, true, true, 40000U, lastSent, 60000U));
+    // "now" 10s after the wrap: only 40,000 ms elapsed, still held.
+    TEST_ASSERT_FALSE(PositionModule::shouldSendPositionToPhone(true, true, true, 10000U, lastSent, 60000U));
+}
+
+// Regression: a send stamped at millis()==0 must still hold the cadence - the never-sent state
+// is the everSentToPhone flag, not a lastSentMs==0 sentinel.
+static void test_sendToPhone_sentAtTimeZeroStillHoldsCadence()
+{
+    TEST_ASSERT_FALSE(PositionModule::shouldSendPositionToPhone(true, true, true, 30000U, 0U, 60000U));
+    TEST_ASSERT_TRUE(PositionModule::shouldSendPositionToPhone(true, true, true, 60000U, 0U, 60000U));
+}
+
 void setUp(void) {}
 
 void tearDown(void) {}
@@ -74,6 +124,13 @@ void setup()
     RUN_TEST(test_effectiveInterval_movingKeepsConfigured);
     RUN_TEST(test_effectiveInterval_longConfiguredWinsOverFloor);
     RUN_TEST(test_effectiveInterval_zeroFloorIsNoOp);
+    RUN_TEST(test_sendToPhone_firstSendIsImmediate);
+    RUN_TEST(test_sendToPhone_holdsUntilCadenceElapses);
+    RUN_TEST(test_sendToPhone_sendsWhenCadenceElapses);
+    RUN_TEST(test_sendToPhone_requiresValidPosition);
+    RUN_TEST(test_sendToPhone_requiresIdlePhoneQueue);
+    RUN_TEST(test_sendToPhone_survivesMillisRollover);
+    RUN_TEST(test_sendToPhone_sentAtTimeZeroStillHoldsCadence);
     exit(UNITY_END());
 }
 

--- a/test/test_stream_api/test_main.cpp
+++ b/test/test_stream_api/test_main.cpp
@@ -1,7 +1,9 @@
 #include "MeshTypes.h"
 #include "SerialConsole.h"
 #include "TestUtil.h"
+#include "UptimeClock.h"
 #include "configuration.h"
+#include "gps/RTC.h"
 #include "mesh-pb-constants.h"
 #include "mesh/MeshService.h"
 #include "mesh/NodeDB.h"
@@ -10,6 +12,7 @@
 #include <algorithm>
 #include <cstdarg>
 #include <cstdint>
+#include <ctime>
 #include <deque>
 #include <limits>
 #include <unity.h>
@@ -522,6 +525,131 @@ static void test_want_config_includes_status_message_module_config(void)
     TEST_ASSERT_TRUE(foundStatusMessageConfig);
 }
 
+/// Queue a packet as Router::dispatchReceived would have, before any time source existed.
+static void queuePendingTimePlaceholderPacket(NodeNum from, uint32_t placeholderMillis)
+{
+    meshtastic_MeshPacket pending = meshtastic_MeshPacket_init_zero;
+    pending.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+    pending.decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;
+    pending.from = from;
+    pending.to = NODENUM_BROADCAST;
+    pending.rx_time = placeholderMillis;
+    pending.has_rx_time = false;
+    service->sendToPhone(packetPool.allocCopy(pending));
+}
+
+static void startHandshake(PhoneAPITestShim &api)
+{
+    meshtastic_ToRadio request = meshtastic_ToRadio_init_zero;
+    request.which_payload_variant = meshtastic_ToRadio_want_config_id_tag;
+    request.want_config_id = SPECIAL_NONCE_ONLY_CONFIG;
+    uint8_t requestBytes[meshtastic_ToRadio_size];
+    const size_t requestSize = pb_encode_to_bytes(requestBytes, sizeof(requestBytes), &meshtastic_ToRadio_msg, &request);
+    api.handleToRadio(requestBytes, requestSize);
+}
+
+/// Drain the config stream looking for the first packet from `from`; false if never delivered.
+static bool drainHandshakeForPacketFrom(PhoneAPITestShim &api, NodeNum from, meshtastic_MeshPacket &outPacket)
+{
+    for (unsigned i = 0; i < 256; ++i) {
+        uint8_t responseBytes[meshtastic_FromRadio_size];
+        const size_t responseSize = api.getFromRadio(responseBytes);
+        if (responseSize == 0)
+            return false;
+        meshtastic_FromRadio response = meshtastic_FromRadio_init_zero;
+        TEST_ASSERT_TRUE(pb_decode_from_bytes(responseBytes, responseSize, &meshtastic_FromRadio_msg, &response));
+        if (response.which_payload_variant == meshtastic_FromRadio_packet_tag && response.packet.from == from) {
+            outPacket = response.packet;
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Swaps in a scratch NodeDB and the injected clock, restoring both plus the RTC on destruction.
+/// Unity's TEST_ASSERT longjmps out on failure, so cleanup must not live at the end of the test.
+class ScopedTimeFixture
+{
+  public:
+    ScopedTimeFixture(uint32_t startMillis) : previous(nodeDB)
+    {
+        resetRTCStateForTests();
+        nodeDB = &instance;
+        Time::setTestMillis(startMillis);
+    }
+    ~ScopedTimeFixture()
+    {
+        nodeDB = previous;
+        Time::useRealClock();
+        resetRTCStateForTests();
+    }
+
+  private:
+    NodeDB instance;
+    NodeDB *previous;
+};
+
+// Time given at the start of the handshake, before the queued packet is drained: reconciliation
+// (fired by the RTC quality crossing hook in RTC.cpp) rewrites the placeholder in place.
+static void test_time_given_at_handshake_start_reconciles_queued_packet(void)
+{
+    ScopedMeshService scopedService;
+    ScopedTimeFixture timeFixture(5000);
+
+    const NodeNum sender = 0x12345678;
+    queuePendingTimePlaceholderPacket(sender, 2000); // "received" 3s before the test's current millis()
+
+    PhoneAPITestShim api;
+    startHandshake(api);
+
+    struct timeval networkTime;
+    networkTime.tv_sec = time(NULL) + SEC_PER_DAY;
+    networkTime.tv_usec = 0;
+    TEST_ASSERT_EQUAL_INT(RTCSetResultSuccess, perhapsSetRTC(RTCQualityFromNet, &networkTime));
+
+    meshtastic_MeshPacket delivered;
+    TEST_ASSERT_TRUE_MESSAGE(drainHandshakeForPacketFrom(api, sender, delivered),
+                             "queued packet was not delivered during the handshake");
+    TEST_ASSERT_TRUE(delivered.has_rx_time);
+    TEST_ASSERT_UINT32_WITHIN(2, (uint32_t)networkTime.tv_sec - 3, delivered.rx_time);
+
+    api.close();
+}
+
+// Time given at the end - after the queued packet already left via the handshake: the delivered
+// copy keeps its unresolved placeholder, since reconciliation can only rewrite what's still queued.
+static void test_time_given_at_handshake_end_does_not_rewrite_already_sent_packet(void)
+{
+    ScopedMeshService scopedService;
+    ScopedTimeFixture timeFixture(5000);
+
+    const NodeNum sender = 0x12345678;
+    queuePendingTimePlaceholderPacket(sender, 2000);
+
+    PhoneAPITestShim api;
+    startHandshake(api);
+
+    // rx_time is proto3 optional, so has_rx_time false omits it from the wire entirely: the
+    // decoded copy reads back 0 and the placeholder itself never left the device.
+    meshtastic_MeshPacket delivered;
+    TEST_ASSERT_TRUE_MESSAGE(drainHandshakeForPacketFrom(api, sender, delivered),
+                             "queued packet was not delivered during the handshake");
+    TEST_ASSERT_FALSE(delivered.has_rx_time);
+    TEST_ASSERT_EQUAL_UINT32(0u, delivered.rx_time);
+
+    // Time-giving transaction happens only now, at the end of the handshake.
+    struct timeval networkTime;
+    networkTime.tv_sec = time(NULL) + SEC_PER_DAY;
+    networkTime.tv_usec = 0;
+    TEST_ASSERT_EQUAL_INT(RTCSetResultSuccess, perhapsSetRTC(RTCQualityFromNet, &networkTime));
+
+    // The already-delivered copy is a value, not a queue reference - untouched either way.
+    TEST_ASSERT_FALSE(delivered.has_rx_time);
+    TEST_ASSERT_EQUAL_UINT32(0u, delivered.rx_time);
+
+    api.close();
+}
+
 /// Unity per-test setup; fixtures are local to each test.
 void setUp(void) {}
 /// Unity per-test teardown; fixtures clean themselves up.
@@ -544,6 +672,8 @@ void setup()
     RUN_TEST(test_lockdown_admin_gate_ignores_wire_from);
     RUN_TEST(test_lockdown_admin_gate_rejects_undecodable_admin);
     RUN_TEST(test_want_config_includes_status_message_module_config);
+    RUN_TEST(test_time_given_at_handshake_start_reconciles_queued_packet);
+    RUN_TEST(test_time_given_at_handshake_end_does_not_rewrite_already_sent_packet);
     // usingProtobufs intentionally has no reset path, so this must run last.
     RUN_TEST(test_serial_console_suppresses_raw_output_in_protobuf_mode);
     exit(UNITY_END());

--- a/test/test_traffic_management/test_main.cpp
+++ b/test/test_traffic_management/test_main.cpp
@@ -766,6 +766,7 @@ static void test_tm_nodeinfo_directResponse_psramCacheRespondsAndPreservesBitfie
     observed.decoded.bitfield = BITFIELD_WANT_RESPONSE_MASK;
     observed.channel = 2;
     observed.rx_time = 123456;
+    observed.has_rx_time = true; // rx_time has explicit presence; mark this synthetic reading as measured
 
     ProcessMessage observedResult = module.handleReceived(observed);
     TEST_ASSERT_EQUAL_INT(static_cast<int>(ProcessMessage::CONTINUE), static_cast<int>(observedResult));

--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -24,6 +24,7 @@
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
+  // "USERPREFS_EVENT_MODE_HOP_LIMIT": "3", // Event-mode default and firmware-generated/relay hop cap (0-7; default 3)
   // "USERPREFS_TMM_APPLY_TO_PRIVATE_CHANNELS": "1", // Extend TMM position dedup and precision clamping to private/custom-key channels (default: well-known channels only)
   // "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_BURNING_MAN",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",

--- a/variants/esp32/esp32-common.ini
+++ b/variants/esp32/esp32-common.ini
@@ -17,6 +17,9 @@ extra_scripts =
   ${env.extra_scripts}
   pre:extra_scripts/esp32_pre.py
   extra_scripts/esp32_extra.py
+  ; Spill long link commands into @response files. Big MUI/TFT images exceed the kernel's
+  ; exec arg limit ("sh: Argument list too long"; rak_wismesh_tap_v2-tft hit it first).
+  extra_scripts/ld_response_file.py
 
 build_src_filter = 
   ${arduino_base.build_src_filter} +<platform/esp32/> -<mesh/eth/> -<mesh/raspihttp>

--- a/variants/esp32p4/esp32p4.ini
+++ b/variants/esp32p4/esp32p4.ini
@@ -15,9 +15,10 @@ build_flags =
 build_src_filter = 
   ${esp32_common.build_src_filter} -<libpax/> +<platform/esp32> -<mesh/raspihttp> -<serialization/>
 
+; ld_response_file.py is inherited from esp32_common (promoted there when
+; rak_wismesh_tap_v2-tft outgrew the exec arg limit; it originally shipped here).
 extra_scripts =
   ${esp32_common.extra_scripts}
-  extra_scripts/ld_response_file.py
 
 ; Override esp32_common component pruning: keep esp_hosted + esp_wifi_remote for P4 hosted BT
 custom_component_remove =

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -32,7 +32,7 @@ build_type = release
 lib_deps =
   ${native_base.lib_deps}
   ${device-ui_base.lib_deps}
-build_flags = ${native_base.build_flags} -Os -lX11 -linput -lxkbcommon -ffunction-sections -fdata-sections -Wl,--gc-sections
+build_flags = ${native_base.build_flags} -Os -lcurl -lX11 -linput -lxkbcommon -ffunction-sections -fdata-sections -Wl,--gc-sections
   -D RAM_SIZE=16384
   -D USE_X11=1
   -D HAS_TFT=1
@@ -60,7 +60,7 @@ build_type = release
 lib_deps =
   ${native_base.lib_deps}
   ${device-ui_base.lib_deps}
-build_flags = ${native_base.build_flags} -Os -ffunction-sections -fdata-sections -Wl,--gc-sections
+build_flags = ${native_base.build_flags} -Os -ffunction-sections -fdata-sections -lcurl -Wl,--gc-sections
   -D RAM_SIZE=8192
   -D USE_FRAMEBUFFER=1
   -D LV_COLOR_DEPTH=32
@@ -79,6 +79,7 @@ build_flags = ${native_base.build_flags} -Os -ffunction-sections -fdata-sections
   -D MAP_FULL_REDRAW
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
+  !pkg-config --cflags --libs sdl2 --silence-errors || :
   !pkg-config --cflags --libs libbsd-overlay --silence-errors || :
 build_src_filter =
   ${native_base.build_src_filter}
@@ -89,12 +90,12 @@ build_type = debug
 lib_deps =
   ${native_base.lib_deps}
   ${device-ui_base.lib_deps}
-build_flags = ${native_base.build_flags} -O0 -fsanitize=address -lX11 -linput -lxkbcommon
+build_flags = ${native_base.build_flags} -g -O0 -fsanitize=address -lcurl -lX11 -linput -lxkbcommon
   -D DEBUG_HEAP
   -D RAM_SIZE=16384
   -D USE_X11=1
   -D HAS_TFT=1
-  -D HAS_SCREEN=0
+  -D HAS_SCREEN=1
   -D LV_CACHE_DEF_SIZE=6291456
   -D LV_BUILD_TEST=0
   -D LV_USE_LOG=1
@@ -112,6 +113,7 @@ build_flags = ${native_base.build_flags} -O0 -fsanitize=address -lX11 -linput -l
   -D VIEW_320x240
   !pkg-config --libs libulfius --silence-errors || :
   !pkg-config --libs openssl --silence-errors || :
+  !pkg-config --cflags --libs sdl2 --silence-errors || :
   !pkg-config --cflags --libs libbsd-overlay --silence-errors || :
 build_src_filter = ${env:native-tft.build_src_filter}
 

--- a/variants/native/portduino/platformio.ini
+++ b/variants/native/portduino/platformio.ini
@@ -423,7 +423,7 @@ build_src_filter =
   +<main.cpp>
   +<PowerFSM.cpp> +<Power.cpp> +<airtime.cpp> +<sleep.cpp>
   +<RedirectablePrint.cpp> +<SerialConsole.cpp> +<Observer.cpp>
-  +<FSCommon.cpp> +<SafeFile.cpp> +<MessageStore.cpp> +<meshUtils.cpp>
+  +<FSCommon.cpp> +<SafeFile.cpp> +<MessageStore.cpp> +<meshUtils.cpp> +<UptimeClock.cpp>
   +<memGet.cpp> +<memory/> +<GpioLogic.cpp> +<PowerMon.cpp> +<SPILock.cpp>
   +<xmodem.cpp> +<DisplayFormatters.cpp>
   +<detect/ScanI2C.cpp> +<detect/ScanI2CTwoWire.cpp> +<detect/ScanI2CConsumer.cpp>

--- a/variants/stm32/stm32.ini
+++ b/variants/stm32/stm32.ini
@@ -2,7 +2,7 @@
 extends = arduino_base
 platform =
   # renovate: datasource=custom.pio depName=platformio/ststm32 packageName=platformio/platform/ststm32
-  platformio/ststm32@19.7.0
+  platformio/ststm32@19.7.1
 platform_packages =
   # renovate: datasource=github-tags depName=Arduino_Core_STM32 packageName=stm32duino/Arduino_Core_STM32
   platformio/framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/2.10.1.zip


### PR DESCRIPTION
## Summary

- Sync the PR branch with current upstream `develop`.
- Preserve accumulated reboot and radio-reconfigure decisions across multi-setting admin transactions, including duplicate `begin_edit_settings` messages.
- Treat byte-identical config, redacted network/MQTT secrets, policy-only LoRa changes, and live-applied LoRa fields as no-op or non-restart changes.
- Reconfigure the radio for primary-channel edits only when the effective frequency selection changes.
- Expire abandoned edit transactions after 60 seconds without requiring later admin traffic, while keeping the timeout thread dormant when no transaction is open.
- Keep BLE available until a transaction actually commits a reboot-requiring change.

## Validation

- `python -m platformio test -e native-macos`: 872/872 passed.
- `test_admin_radio`: 160/160 passed, including transaction timeout, no-op, restart, radio-reconfigure, secret-redaction, and timer-idle coverage.
- `pio run -e t-echo`: passed; 37.8% RAM, 94.4% flash, warm-region/ISR/variant guards passed.
- `pio run -e tbeam-s3-core`: passed; 31.0% RAM, 71.7% flash.
- `trunk fmt` and `git diff --check`: passed.

## Hardware evidence

Flashed a T-Echo with `2.8.0.686d358` and preserved its node identity, owner, US/default channel, and five-node database. Live admin transactions confirmed that display, LoRa, channel, redacted MQTT, and Serial no-ops do not reconfigure the radio, disable BLE, or reboot. A physical LoRa setting change reconfigured the radio once without rebooting.

An intentionally abandoned reboot-requiring Serial transaction expired after 62.3 seconds, logged the timeout, disabled BLE, rebooted once, returned on serial with the same node identity, and persisted the change. The original Serial config was then restored byte-for-byte.

Primary-channel rename behavior is covered by native tests; the live Python client did not retain a custom rename on this default-channel T-Echo, so this does not claim on-device rename validation.