### PR TITLE
Fix non-blocking uptime publication and pre-clock recency edges

### DIFF
--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -54,14 +54,14 @@ jobs:
           fi
           echo "native-suite-count matches the $expected_count suite directories."
 
-  # Reject naive deadline comparisons against millis(). `millis() > deadline` and
+  # Reject naive deadline comparisons against the 32-bit uptime clocks. `millis() > deadline` and
   # `deadline < millis()` invert while the deadline sits on the far side of the 32-bit wrap: the
   # action fires immediately, or blocks for about the interval it should have waited. The correct
   # forms are
   # Throttle::isWithinTimespanMs / hasElapsed (elapsed since a stored event) and
   # Throttle::deadlinePassed (an absolute deadline). See .github/copilot-instructions.md.
   millis-deadline-check:
-    name: Naive millis() Deadline Compare
+    name: Naive Uptime Deadline Compare
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,15 +70,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Reject millis() used directly in a deadline comparison
+      - name: Reject 32-bit uptime clocks used directly in a deadline comparison
         shell: bash
         run: |
           set -euo pipefail
           allowlist=".github/millis-deadline-allowlist.txt"
 
-          # Flag millis() directly adjacent to a comparison operator, in either order. The correct
-          # idioms all subtract first - `(int32_t)(millis() - deadline) < 0`, `now - last >= span` -
-          # so they never place millis() next to the operator and are not matched.
+          # Flag millis() or its Time::getMillis() wrapper directly adjacent to a comparison
+          # operator, in either order. The correct idioms subtract first, so they are not matched.
           #
           # Line comments are stripped before matching, so prose may name the broken idiom (this
           # guard's own documentation does). Block comments are not stripped; keep `millis() >` out
@@ -89,7 +88,7 @@ jobs:
               {
                 line = $0
                 sub(/\/\/.*/, "", line)
-                if (line ~ /(millis\(\)[ \t]*[<>]=?)|([<>]=?[ \t]*millis\(\))/) {
+                if (line ~ /((millis|Time::getMillis)\(\)[ \t]*[<>]=?)|([<>]=?[ \t]*(millis|Time::getMillis)\(\))/) {
                   code = line
                   sub(/^[ \t]+/, "", code); sub(/[ \t]+$/, "", code)
                   printf "%s\t%s\t%s\n", FILENAME, FNR, code
@@ -114,10 +113,10 @@ jobs:
           done < /tmp/millis-hits.tsv
 
           if [[ $violations -gt 0 ]]; then
-            echo "::error title=Naive millis() deadline compare::$violations line(s) compare against millis() directly, which inverts while the deadline is on the far side of the 32-bit wrap - the action fires immediately, or blocks for about the interval it should have waited. Use Throttle::deadlinePassed(deadline) for a stored absolute deadline, or Throttle::hasElapsed(lastEvent, intervalMs) for an interval. If a match genuinely is not a deadline test (an uptime threshold, say), add it to $allowlist with a reason."
+            echo "::error title=Naive uptime deadline compare::$violations line(s) compare a 32-bit uptime clock directly, which inverts while the deadline is on the far side of the 32-bit wrap - the action fires immediately, or blocks for about the interval it should have waited. Use Throttle::deadlinePassed(deadline) for a stored absolute deadline, or Throttle::hasElapsed(lastEvent, intervalMs) for an interval. If a match genuinely is not a deadline test (an uptime threshold, say), add it to $allowlist with a reason."
             exit 1
           fi
-          echo "No naive millis() deadline comparisons in src/ (allowlist: $(wc -l < /tmp/millis-allowed.tsv) entr(y/ies))."
+          echo "No naive 32-bit uptime deadline comparisons in src/ (allowlist: $(wc -l < /tmp/millis-allowed.tsv) entr(y/ies))."
 
   simulator-tests:
     name: Native Simulator Tests

--- a/.github/workflows/test_native.yml
+++ b/.github/workflows/test_native.yml
@@ -88,7 +88,7 @@ jobs:
               {
                 line = $0
                 sub(/\/\/.*/, "", line)
-                if (line ~ /((millis|Time::getMillis)\(\)[ \t]*[<>]=?)|([<>]=?[ \t]*(millis|Time::getMillis)\(\))/) {
+                if (line ~ /((millis|getMillis)\(\)[ \t]*[<>]=?)|([<>]=?[ \t]*(millis|getMillis)\(\))/) {
                   code = line
                   sub(/^[ \t]+/, "", code); sub(/[ \t]+$/, "", code)
                   printf "%s\t%s\t%s\n", FILENAME, FNR, code

--- a/src/UptimeClock.cpp
+++ b/src/UptimeClock.cpp
@@ -14,12 +14,16 @@ uint32_t Time::getMillis()
 
 namespace
 {
-// The wrap carry, published by Time::serviceMonotonic() and read by everyone else. Split into two
-// 32-bit atomics behind a sequence counter: a 64-bit store is not atomic on a 32-bit MCU and the
-// halves must be read as a matched pair. Odd sequence = publish in progress.
-std::atomic<uint32_t> publishSeq{0};
-std::atomic<uint32_t> publishedHigh{0}; // wraps counted as of the last publish
-std::atomic<uint32_t> publishedLow{0};  // getMillis() at the last publish
+struct PublishedSnapshot {
+    std::atomic<uint32_t> high{0};
+    std::atomic<uint32_t> low{0};
+};
+
+PublishedSnapshot published[2];
+std::atomic<uint32_t> publishedGeneration{0};
+#ifdef PIO_UNIT_TESTING
+std::atomic<Time::MonotonicPublishHook> monotonicPublishHook{nullptr};
+#endif
 
 // Extend a published (high, low) snapshot to `now`. Unsigned subtraction is exact across the wrap
 // for any gap under 49.7 days, so neither caller inspects the boundary. One copy: the reader and
@@ -29,17 +33,17 @@ uint64_t extendPublished(uint32_t high, uint32_t low, uint32_t now)
     return ((((uint64_t)high << 32) | low) + (uint32_t)(now - low));
 }
 
-// Seqlock read. Single writer, so this only ever retries against a publish in flight.
+// A generation change means the writer completed a publish while this copy was being read. A
+// paused publish leaves the generation unchanged and writes only the inactive snapshot.
 void readPublished(uint32_t &high, uint32_t &low)
 {
     for (;;) {
-        const uint32_t before = publishSeq.load(std::memory_order_acquire);
-        if (before & 1u)
-            continue;
-        high = publishedHigh.load(std::memory_order_relaxed);
-        low = publishedLow.load(std::memory_order_relaxed);
+        const uint32_t before = publishedGeneration.load(std::memory_order_acquire);
+        PublishedSnapshot &snapshot = published[before & 1u];
+        high = snapshot.high.load(std::memory_order_relaxed);
+        low = snapshot.low.load(std::memory_order_relaxed);
         std::atomic_thread_fence(std::memory_order_acquire);
-        if (publishSeq.load(std::memory_order_relaxed) == before)
+        if (publishedGeneration.load(std::memory_order_relaxed) == before)
             return;
     }
 }
@@ -60,23 +64,35 @@ uint32_t Time::getUptimeSecs()
 
 void Time::serviceMonotonic()
 {
-    const uint32_t low = publishedLow.load(std::memory_order_relaxed);
-    const uint32_t high = publishedHigh.load(std::memory_order_relaxed);
+    const uint32_t generation = publishedGeneration.load(std::memory_order_relaxed);
+    PublishedSnapshot &active = published[generation & 1u];
+    const uint32_t low = active.low.load(std::memory_order_relaxed);
+    const uint32_t high = active.high.load(std::memory_order_relaxed);
     const uint64_t next = extendPublished(high, low, getMillis());
 
-    const uint32_t seq = publishSeq.load(std::memory_order_relaxed);
-    publishSeq.store(seq + 1, std::memory_order_relaxed); // odd: publish in progress
-    std::atomic_thread_fence(std::memory_order_release);
-    publishedHigh.store((uint32_t)(next >> 32), std::memory_order_relaxed);
-    publishedLow.store((uint32_t)next, std::memory_order_relaxed);
-    publishSeq.store(seq + 2, std::memory_order_release); // even: stable
+    PublishedSnapshot &inactive = published[(generation + 1u) & 1u];
+    inactive.high.store((uint32_t)(next >> 32), std::memory_order_relaxed);
+    inactive.low.store((uint32_t)next, std::memory_order_relaxed);
+#ifdef PIO_UNIT_TESTING
+    if (const auto hook = monotonicPublishHook.load(std::memory_order_relaxed))
+        hook();
+#endif
+    publishedGeneration.store(generation + 1u, std::memory_order_release);
 }
 
 #ifdef PIO_UNIT_TESTING
 void Time::resetMonotonicForTests()
 {
-    publishSeq.store(0, std::memory_order_relaxed);
-    publishedHigh.store(0, std::memory_order_relaxed);
-    publishedLow.store(0, std::memory_order_relaxed);
+    publishedGeneration.store(0, std::memory_order_relaxed);
+    for (auto &snapshot : published) {
+        snapshot.high.store(0, std::memory_order_relaxed);
+        snapshot.low.store(0, std::memory_order_relaxed);
+    }
+    monotonicPublishHook.store(nullptr, std::memory_order_relaxed);
+}
+
+void Time::setMonotonicPublishHookForTests(MonotonicPublishHook hook)
+{
+    monotonicPublishHook.store(hook, std::memory_order_relaxed);
 }
 #endif

--- a/src/UptimeClock.cpp
+++ b/src/UptimeClock.cpp
@@ -19,6 +19,7 @@ struct PublishedSnapshot {
     std::atomic<uint32_t> low{0};
 };
 
+// The constexpr atomic initializers make both snapshots available before firmware startup.
 PublishedSnapshot published[2];
 std::atomic<uint32_t> publishedGeneration{0};
 #ifdef PIO_UNIT_TESTING

--- a/src/UptimeClock.h
+++ b/src/UptimeClock.h
@@ -15,6 +15,7 @@ namespace Time
 // test_uptime_clock/ do exactly that.
 inline std::atomic<uint32_t> testNowMs{0};
 inline std::atomic<bool> useTestClock{false};
+using MonotonicPublishHook = void (*)();
 
 inline void setTestMillis(uint32_t ms)
 {
@@ -35,6 +36,7 @@ inline void useRealClock()
 // Zero the published wrap carry. Suites that assert absolute uptime values call this in setUp():
 // a previous case that moved the test clock backwards left a counted wrap behind.
 void resetMonotonicForTests();
+void setMonotonicPublishHookForTests(MonotonicPublishHook hook);
 #endif
 
 /// Milliseconds since boot, 32-bit (wraps ~49.7 days). Drop-in for millis(), and the only clock
@@ -45,13 +47,11 @@ uint32_t getMillis();
 
 /// Milliseconds since boot as a monotonic 64-bit count.
 ///
-/// A pure read: it derives its answer from the snapshot published by serviceMonotonic() plus the
-/// unsigned elapsed time since that snapshot, which is exact across the wrap. A reader therefore
-/// never inspects the wrap boundary and never mutates shared state, so any number of threads may
-/// call it concurrently without being able to miscount a wrap.
+/// A pure read: it derives its answer from a complete snapshot published by serviceMonotonic()
+/// plus the unsigned elapsed time since that snapshot, which is exact across the wrap. A reader
+/// that preempts publication uses the previous snapshot instead of waiting for the writer.
 ///
-/// Not ISR-safe: the snapshot is read under a seqlock, and an ISR that preempts serviceMonotonic()
-/// mid-publish would spin. ISRs use getMillis().
+/// Not intended for ISR call sites; they use getMillis().
 uint64_t getMillisMonotonic();
 
 /// Whole seconds since boot, derived from getMillisMonotonic() (~136 years of range). This is

--- a/src/UptimeClock.h
+++ b/src/UptimeClock.h
@@ -39,19 +39,20 @@ void resetMonotonicForTests();
 void setMonotonicPublishHookForTests(MonotonicPublishHook hook);
 #endif
 
-/// Milliseconds since boot, 32-bit (wraps ~49.7 days). Drop-in for millis(), and the only clock
-/// read here that is safe from an ISR. For "has this interval elapsed / deadline arrived" use
-/// Throttle (isWithinTimespanMs / hasElapsed / deadlinePassed), which is wrap-correct with no
-/// carry state at all.
+/// Milliseconds since boot, 32-bit (wraps ~49.7 days). Drop-in for millis(). For "has this interval
+/// elapsed / deadline arrived" use Throttle (isWithinTimespanMs / hasElapsed / deadlinePassed),
+/// which is wrap-correct with no carry state at all.
 uint32_t getMillis();
 
 /// Milliseconds since boot as a monotonic 64-bit count.
 ///
 /// A pure read: it derives its answer from a complete snapshot published by serviceMonotonic()
 /// plus the unsigned elapsed time since that snapshot, which is exact across the wrap. A reader
-/// that preempts publication uses the previous snapshot instead of waiting for the writer.
+/// that preempts publication uses the previous snapshot. If publication completes during a copy,
+/// the reader retries; it never waits for a publish in progress.
 ///
-/// Not intended for ISR call sites; they use getMillis().
+/// Not intended for ISR call sites because lock-free std::atomic operations are not guaranteed by
+/// every supported toolchain. ISRs use getMillis(); the publication protocol itself never waits.
 uint64_t getMillisMonotonic();
 
 /// Whole seconds since boot, derived from getMillisMonotonic() (~136 years of range). This is

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -3649,7 +3649,7 @@ void NodeDB::updateFrom(const meshtastic_MeshPacket &mp)
         // Gate on has_rx_time, not truthiness - rx_time may hold an uptime-seconds placeholder.
         if (mp.has_rx_time)
             info->last_heard = mp.rx_time;
-        else if (mp.rx_time)
+        else
             // The placeholder is the packet's arrival instant in uptime seconds. Keep it in the
             // RAM sidecar so the clock-valid transition can date this sighting; last_heard itself
             // only ever holds a real epoch or 0.
@@ -4092,22 +4092,29 @@ void NodeDB::recordHeardWhileClockUntrusted(NodeNum num, uint32_t heardAtUptime)
     victim->heardAtUptimeSecs = heardAtUptime;
 }
 
-uint32_t NodeDB::heardAtUptimeSecs(NodeNum num) const
+bool NodeDB::getHeardAtUptimeSecs(NodeNum num, uint32_t &stamp) const
 {
     for (const auto &h : heardAt) {
-        if (h.num == num)
-            return h.heardAtUptimeSecs;
+        if (h.num == num) {
+            stamp = h.heardAtUptimeSecs;
+            return true;
+        }
     }
-    return 0;
+    return false;
 }
 
-uint32_t NodeDB::evictionRecency(const meshtastic_NodeInfoLite *n) const
+NodeDB::EvictionRecency NodeDB::evictionRecency(const meshtastic_NodeInfoLite *n) const
 {
-    const uint32_t stamp = heardAtUptimeSecs(n->num);
-    // A RAM stamp means heard this boot but not yet datable: more recent than anything dated
-    // before this boot. The 2^31 bias keeps stamps above every pre-2038 epoch while preserving
-    // their order among themselves.
-    return stamp ? 0x80000000u + stamp : n->last_heard;
+    uint32_t stamp = 0;
+    const bool heardThisBoot = getHeardAtUptimeSecs(n->num, stamp);
+    return {heardThisBoot ? stamp : n->last_heard, heardThisBoot};
+}
+
+bool NodeDB::evictionRecencyOlder(EvictionRecency candidate, EvictionRecency incumbent)
+{
+    if (candidate.heardThisBoot != incumbent.heardThisBoot)
+        return !candidate.heardThisBoot;
+    return candidate.value < incumbent.value;
 }
 
 void NodeDB::stampContactHeardNow(meshtastic_NodeInfoLite *info)
@@ -4151,8 +4158,8 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
             LOG_INFO("Node database full with %i nodes and %u bytes free. Erasing oldest entry", numMeshNodes,
                      memGet.getFreeHeap());
             // look for oldest node and erase it
-            uint32_t oldest = UINT32_MAX;
-            uint32_t oldestBoring = UINT32_MAX;
+            EvictionRecency oldest = {};
+            EvictionRecency oldestBoring = {};
             int oldestIndex = -1;
             int oldestBoringIndex = -1;
             for (int i = 1; i < numMeshNodes; i++) {
@@ -4162,14 +4169,16 @@ meshtastic_NodeInfoLite *NodeDB::getOrCreateMeshNode(NodeNum n)
                 const bool isVerified = nodeInfoLiteIsKeyManuallyVerified(cand);
                 // last_heard, except that nodes heard this boot before the clock became trusted
                 // rank by their RAM arrival stamp instead of the 0 in the stored field.
-                const uint32_t candRecency = evictionRecency(cand);
+                const EvictionRecency candRecency = evictionRecency(cand);
                 // Simply the oldest non-favorite, non-ignored, non-verified node
-                if (!isFavoriteNode && !isIgnored && !isVerified && candRecency < oldest) {
+                if (!isFavoriteNode && !isIgnored && !isVerified &&
+                    (oldestIndex == -1 || evictionRecencyOlder(candRecency, oldest))) {
                     oldest = candRecency;
                     oldestIndex = i;
                 }
                 // The oldest "boring" node
-                if (!isFavoriteNode && !isIgnored && cand->public_key.size == 0 && candRecency < oldestBoring) {
+                if (!isFavoriteNode && !isIgnored && cand->public_key.size == 0 &&
+                    (oldestBoringIndex == -1 || evictionRecencyOlder(candRecency, oldestBoring))) {
                     oldestBoring = candRecency;
                     oldestBoringIndex = i;
                 }

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -660,12 +660,17 @@ class NodeDB
     /// RAM arrival stamp that evictionRecency() honours - never a boot-relative last_heard.
     void stampContactHeardNow(meshtastic_NodeInfoLite *info);
 
-    /// The node's RAM arrival stamp, or 0 if it has none.
-    uint32_t heardAtUptimeSecs(NodeNum num) const;
+    /// Read the node's RAM arrival stamp. The boolean carries presence because uptime second 0 is valid.
+    bool getHeardAtUptimeSecs(NodeNum num, uint32_t &stamp) const;
 
-    /// last_heard for eviction ranking, with RAM-stamped nodes ranked above every stored epoch:
-    /// a node heard this boot is more recent than anything dated before it.
-    uint32_t evictionRecency(const meshtastic_NodeInfoLite *n) const;
+    struct EvictionRecency {
+        uint32_t value;
+        bool heardThisBoot;
+    };
+
+    /// Eviction ranking with current-boot stamps newer than every persisted epoch.
+    EvictionRecency evictionRecency(const meshtastic_NodeInfoLite *n) const;
+    static bool evictionRecencyOlder(EvictionRecency candidate, EvictionRecency incumbent);
 
     /*
      * Internal boolean to track sorting paused

--- a/test/test_nodedb_blocked/test_main.cpp
+++ b/test/test_nodedb_blocked/test_main.cpp
@@ -25,6 +25,7 @@ class NodeDBTestShim : public NodeDB
   public:
     void runDemote() { demoteOldestHotNodesToWarm(); }
     void runCleanup() { cleanupMeshDB(); }
+    void stampUntrusted(NodeNum num, uint32_t uptimeSecs) { recordHeardWhileClockUntrusted(num, uptimeSecs); }
 
     // Read back the role + protected category the warm tier cached for a node.
     bool warmMeta(NodeNum n, uint8_t &role, uint8_t &prot) { return warmStore.lookupMeta(n, role, prot); }
@@ -178,6 +179,27 @@ static void test_eviction_preservesFavorite(void)
     TEST_ASSERT_NOT_NULL(db->getMeshNode(0x99990000));
 }
 
+// A node heard during this boot is newer than every persisted epoch, including valid epochs after
+// 2038. Ranking both domains in one uint32_t incorrectly evicts the current-boot node first.
+static void test_eviction_prefers_current_boot_stamp_over_post2038_epoch(void)
+{
+    constexpr NodeNum futureDated = 0x70000001;
+    constexpr NodeNum heardThisBoot = 0x70000002;
+
+    db->seedSelf();
+    db->push(futureDated, 0xB5000000u, false, false, /*withUser=*/true, /*withKey=*/true);
+    db->push(heardThisBoot, 0, false, false, /*withUser=*/true, /*withKey=*/true);
+    db->stampUntrusted(heardThisBoot, 10);
+    for (int i = 3; i < MAX_NUM_NODES; i++)
+        db->push(0x70000000u + i, UINT32_MAX, false, false, /*withUser=*/true, /*withKey=*/true);
+
+    TEST_ASSERT_EQUAL_INT(MAX_NUM_NODES, (int)db->getNumMeshNodes());
+    TEST_ASSERT_NOT_NULL(db->getOrCreateMeshNode(0x79999999));
+
+    TEST_ASSERT_NULL(db->getMeshNode(futureDated));
+    TEST_ASSERT_NOT_NULL(db->getMeshNode(heardThisBoot));
+}
+
 // Ignored handling: an ignored node survives eviction (like a favourite), and is
 // never purged by cleanupMeshDB even with no user info (a block set by bare ID).
 static void test_ignored_survivesEvictionAndCleanup(void)
@@ -269,6 +291,7 @@ NDB_TEST_ENTRY void setup()
     RUN_TEST(test_migration_carriesRoleAndProtectedIntoWarm);
     RUN_TEST(test_migration_carriesSignerBitThroughWarm);
     RUN_TEST(test_eviction_preservesFavorite);
+    RUN_TEST(test_eviction_prefers_current_boot_stamp_over_post2038_epoch);
     RUN_TEST(test_ignored_survivesEvictionAndCleanup);
     RUN_TEST(test_protectedCap_refusesBeyondLimit);
     RUN_TEST(test_removeNodeByNum_absentNodeOnFullDb);

--- a/test/test_stream_api/test_main.cpp
+++ b/test/test_stream_api/test_main.cpp
@@ -683,6 +683,36 @@ static void test_node_heard_before_time_gets_last_heard_backfilled(void)
     TEST_ASSERT_UINT32_WITHIN(2, (uint32_t)networkTime.tv_sec - 3, info->last_heard);
 }
 
+// Uptime zero is a valid arrival instant during the first second of boot. It must not be confused
+// with an absent sidecar record when network time arrives.
+static void test_node_heard_during_first_uptime_second_gets_last_heard_backfilled(void)
+{
+    ScopedMeshService scopedService;
+    ScopedTimeFixture timeFixture(500);
+
+    const NodeNum sender = 0x33445566;
+    TEST_ASSERT_NOT_NULL(nodeDB->getOrCreateMeshNode(sender));
+    meshtastic_MeshPacket heard = meshtastic_MeshPacket_init_zero;
+    heard.which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+    heard.decoded.portnum = meshtastic_PortNum_TEXT_MESSAGE_APP;
+    heard.from = sender;
+    heard.to = NODENUM_BROADCAST;
+    heard.rx_time = 0; // received during uptime second zero
+    heard.has_rx_time = false;
+    nodeDB->updateFrom(heard);
+
+    const meshtastic_NodeInfoLite *info = nodeDB->getMeshNode(sender);
+    TEST_ASSERT_NOT_NULL(info);
+    TEST_ASSERT_EQUAL_UINT32(0u, info->last_heard);
+
+    struct timeval networkTime;
+    networkTime.tv_sec = time(NULL) + SEC_PER_DAY;
+    networkTime.tv_usec = 0;
+    TEST_ASSERT_EQUAL_INT(RTCSetResultSuccess, perhapsSetRTC(RTCQualityFromNet, &networkTime));
+
+    TEST_ASSERT_UINT32_WITHIN(1, (uint32_t)networkTime.tv_sec, info->last_heard);
+}
+
 /// Unity per-test setup; fixtures are local to each test.
 void setUp(void) {}
 /// Unity per-test teardown; fixtures clean themselves up.
@@ -708,6 +738,7 @@ void setup()
     RUN_TEST(test_time_given_at_handshake_start_reconciles_queued_packet);
     RUN_TEST(test_time_given_at_handshake_end_does_not_rewrite_already_sent_packet);
     RUN_TEST(test_node_heard_before_time_gets_last_heard_backfilled);
+    RUN_TEST(test_node_heard_during_first_uptime_second_gets_last_heard_backfilled);
     // usingProtobufs intentionally has no reset path, so this must run last.
     RUN_TEST(test_serial_console_suppresses_raw_output_in_protobuf_mode);
     exit(UNITY_END());

--- a/test/test_uptime_clock/test_main.cpp
+++ b/test/test_uptime_clock/test_main.cpp
@@ -220,13 +220,19 @@ void test_monotonic_reader_completes_while_publish_is_paused()
     while (!publishPaused.load(std::memory_order_acquire))
         std::this_thread::yield();
 
+    std::atomic<bool> readerStarted{false};
     std::atomic<bool> readerDone{false};
     uint64_t readerValue = 0;
-    std::thread reader([&readerDone, &readerValue]() {
+    std::thread reader([&readerStarted, &readerDone, &readerValue]() {
+        readerStarted.store(true, std::memory_order_release);
         readerValue = Time::getMillisMonotonic();
         readerDone.store(true, std::memory_order_release);
     });
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    while (!readerStarted.load(std::memory_order_acquire))
+        std::this_thread::yield();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+    while (!readerDone.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::yield();
     const bool completedWhilePaused = readerDone.load(std::memory_order_acquire);
 
     releasePublish.store(true, std::memory_order_release);

--- a/test/test_uptime_clock/test_main.cpp
+++ b/test/test_uptime_clock/test_main.cpp
@@ -8,11 +8,25 @@
 #include "UptimeClock.h"
 #include "gps/RTC.h"
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <sys/time.h>
 #include <thread>
 #include <unity.h>
 #include <vector>
+
+namespace
+{
+std::atomic<bool> publishPaused{false};
+std::atomic<bool> releasePublish{false};
+
+void pauseMonotonicPublish()
+{
+    publishPaused.store(true, std::memory_order_release);
+    while (!releasePublish.load(std::memory_order_acquire))
+        std::this_thread::yield();
+}
+} // namespace
 
 void setUp(void)
 {
@@ -190,6 +204,40 @@ void test_monotonic_exact_with_concurrent_readers()
     TEST_ASSERT_EQUAL_UINT64(expected, Time::getMillisMonotonic());
 }
 
+// nRF BLE callbacks run above the main loop. A reader that preempts publication must be able to
+// consume the previous complete snapshot without waiting for the suspended writer.
+void test_monotonic_reader_completes_while_publish_is_paused()
+{
+    Time::setTestMillis(100);
+    Time::serviceMonotonic();
+    Time::advanceTestMillis(1);
+
+    publishPaused.store(false, std::memory_order_relaxed);
+    releasePublish.store(false, std::memory_order_relaxed);
+    Time::setMonotonicPublishHookForTests(pauseMonotonicPublish);
+
+    std::thread writer([]() { Time::serviceMonotonic(); });
+    while (!publishPaused.load(std::memory_order_acquire))
+        std::this_thread::yield();
+
+    std::atomic<bool> readerDone{false};
+    uint64_t readerValue = 0;
+    std::thread reader([&readerDone, &readerValue]() {
+        readerValue = Time::getMillisMonotonic();
+        readerDone.store(true, std::memory_order_release);
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    const bool completedWhilePaused = readerDone.load(std::memory_order_acquire);
+
+    releasePublish.store(true, std::memory_order_release);
+    writer.join();
+    reader.join();
+    Time::setMonotonicPublishHookForTests(nullptr);
+
+    TEST_ASSERT_TRUE_MESSAGE(completedWhilePaused, "reader waited for a lower-priority publisher");
+    TEST_ASSERT_EQUAL_UINT64(101u, readerValue);
+}
+
 // --- getTime(): the wall clock must not retreat at the millis() wrap ---
 
 // Epoch used by the wall-clock cases; must sit between BUILD_EPOCH (stamped at build time) and
@@ -291,6 +339,7 @@ void setup()
     RUN_TEST(test_monotonic_misses_a_wrap_not_serviced_within_the_window);
     RUN_TEST(test_getUptimeSecs_stays_exact_across_the_wrap);
     RUN_TEST(test_monotonic_exact_with_concurrent_readers);
+    RUN_TEST(test_monotonic_reader_completes_while_publish_is_paused);
     RUN_TEST(test_getTime_stays_exact_across_the_wrap);
     RUN_TEST(test_getTime_anchored_after_a_wrap_is_exact);
     RUN_TEST(test_getTime_unaffected_by_concurrent_readers_across_the_wrap);


### PR DESCRIPTION
## Summary

- replace the spinning uptime seqlock with generation-tagged double buffering, so a higher-priority reader can use the previous complete snapshot when it preempts the sole publisher
- preserve pre-clock node sightings from uptime second zero and rank current-boot sightings by provenance instead of encoding them into the epoch value domain
- preventively extend the deadline-comparison CI guard to cover raw `millis()`, qualified `Time::getMillis()`, and unqualified `getMillis()`

## Why

On nRF52, BLE callbacks can run above the main loop. If a callback preempts `serviceMonotonic()` while the sequence is odd, the existing reader spins while the only writer is suspended. The double-buffered publisher writes an inactive snapshot and changes one generation word only after the snapshot is complete, so readers never wait for an in-progress lower-priority writer. A reader may retry if a publication completes during its copy, but that retry depends only on an already-progressing publisher.

The pre-clock NodeDB sidecar also used zero as both a valid first-second timestamp and an absence sentinel. Presence is now explicit, preserving a node heard during uptime second zero. Eviction now compares provenance before timestamp value; removing the `0x80000000` epoch-domain bias also future-proofs ordering after January 2038.

`getMillisMonotonic()` remains excluded from ISR call sites because lock-free `std::atomic` operations are not guaranteed by every supported toolchain. ISRs continue to use `getMillis()`; the double-buffer publication protocol itself does not wait.

## Validation

- `./bin/run-tests.sh -e native` at `474c5aeb2`: `RESULT: GREEN 46/46 suites passed [canonical: 46/46]` (864/864 test cases)
- `./bin/run-tests.sh -e native-macos -f test_uptime_clock`: 16/16 passed
- focused clock/stream/NodeDB regression set: 42/42 passed
- compile checks for `t-echo`, `muzi-base`, `tlora-t3s3-v1`, and `tbeam-s3-core`: passed
- `trunk fmt` and `git diff --check`: passed
- deadline-guard fixtures: unsafe raw, qualified, and unqualified clock comparisons are rejected; `getMillisMonotonic()` remains outside the 32-bit deadline guard

## Hardware evidence

Normal update flashes used production artifact commit `4bc4beca0`; later commits only make the test deterministic, extend the CI guard, and clarify the clock contract.

- T-Echo (`t-echo`): serial DFU passed; booted `2.8.0.4bc4bec`; exported owner/channel/config matched the pre-flash snapshot; 50/50 consecutive metadata requests passed in 8.55 s; live uptime advanced from 824 s to 2,631 s without a restart
- Muzi Base (`muzi-base`): serial DFU passed; booted `2.8.0.4bc4bec`; exported owner/channel/config matched the pre-flash snapshot
- T-Beam S3 Core (`tbeam-s3-core`): serial update passed; booted `2.8.0.4bc4bec`; exported owner/channel/config matched the pre-flash snapshot
- T3S3 (`tlora-t3s3-v1`): **unverified for this change**. The esptool write and flash hash verification passed, but a concurrent bench operation made the post-flash verdict inconclusive. The device later boot-looped while mounting a corrupted LittleFS superblock. The matching ELF resolved the panic to `lfs_mount_` at `lfs->seed % lfs->block_count`; a known-good app-only flash reproduced the same loop until LittleFS was replaced, so this was not attributed to the time changes. Recovery restored firmware `2.8.0.41537bf`, the original node number, identity keys, owner, channel, and a byte-for-byte equivalent exported configuration.

T-Echo BLE metadata was not counted as a success: macOS rejected the existing bond with `Peer removed pairing information`. Three bounded attempts left the device immediately healthy on serial. Muzi's Python BLE metadata path hit its known client-side timeout and likewise left serial liveness intact.
